### PR TITLE
moved imports to later in code

### DIFF
--- a/src/model_benchmark_zoo/cuboid.py
+++ b/src/model_benchmark_zoo/cuboid.py
@@ -1,6 +1,4 @@
 import cadquery as cq
-import openmc
-from cad_to_dagmc import CadToDagmc
 
 
 class Cuboid:
@@ -9,6 +7,8 @@ class Cuboid:
         self.materials = materials
 
     def csg_model(self):
+        import openmc
+        
         surface = openmc.model.RectangularParallelepiped(
             -0.5*self.width,
             0.5*self.width,
@@ -35,6 +35,9 @@ class Cuboid:
         self.cadquery_assembly().save(filename, "STEP")
 
     def dagmc_model(self, filename="Cuboid.h5m", min_mesh_size=0.1, max_mesh_size=100.0):
+        from cad_to_dagmc import CadToDagmc
+        import openmc
+
         assembly = self.cadquery_assembly()
         ctd = CadToDagmc()
         material_tags = [self.materials[0].name]

--- a/src/model_benchmark_zoo/sphere.py
+++ b/src/model_benchmark_zoo/sphere.py
@@ -1,6 +1,4 @@
 import cadquery as cq
-import openmc
-from cad_to_dagmc import CadToDagmc
 
 
 class Sphere:
@@ -9,6 +7,8 @@ class Sphere:
         self.materials = materials
 
     def csg_model(self):
+        import openmc
+
         surface = openmc.Sphere(r=self.radius, boundary_type="vacuum")
         region = -surface
         cell = openmc.Cell(region=region)
@@ -28,6 +28,9 @@ class Sphere:
         self.cadquery_assembly().save(filename, "STEP")
 
     def dagmc_model(self, filename="sphere.h5m", min_mesh_size=0.1, max_mesh_size=100.0):
+        from cad_to_dagmc import CadToDagmc
+        import openmc
+        
         assembly = self.cadquery_assembly()
         ctd = CadToDagmc()
         material_tags = [self.materials[0].name]

--- a/src/model_benchmark_zoo/sphericalshell.py
+++ b/src/model_benchmark_zoo/sphericalshell.py
@@ -1,7 +1,4 @@
 import cadquery as cq
-import openmc
-from cad_to_dagmc import CadToDagmc
-
 
 class SphericalShell:
     def __init__(self, materials, radius1=10, radius2=5):
@@ -10,6 +7,8 @@ class SphericalShell:
         self.materials = materials
 
     def csg_model(self):
+        import openmc
+        
         surface1 = openmc.Sphere(r=self.radius1)
         surface2 = openmc.Sphere(r=self.radius1+self.radius2, boundary_type="vacuum")
         region1 = -surface1
@@ -34,6 +33,9 @@ class SphericalShell:
         self.cadquery_assembly().save(filename, "STEP")
 
     def dagmc_model(self, filename="sphericalshell.h5m", min_mesh_size=0.1, max_mesh_size=100.0):
+        from cad_to_dagmc import CadToDagmc
+        import openmc
+        
         assembly = self.cadquery_assembly()
         ctd = CadToDagmc()
         material_tags = [self.materials[0].name, self.materials[1].name]

--- a/src/model_benchmark_zoo/two_touching_cuboids.py
+++ b/src/model_benchmark_zoo/two_touching_cuboids.py
@@ -1,6 +1,4 @@
 import cadquery as cq
-import openmc
-from cad_to_dagmc import CadToDagmc
 
 #     *----------*
 #     |          |
@@ -18,6 +16,7 @@ class TwoTouchingCuboids:
         self.materials = materials
 
     def csg_model(self):
+        import openmc
         surface1 = openmc.ZPlane(z0=self.width1*0.5, boundary_type="vacuum")
         surface2 = openmc.ZPlane(z0=self.width1*-0.5, boundary_type="vacuum")
         surface3 = openmc.XPlane(x0=self.width1*0.5, boundary_type="vacuum")
@@ -51,7 +50,11 @@ class TwoTouchingCuboids:
         self.cadquery_assembly().save(filename, "STEP")
 
     def dagmc_model(self, filename="TwoTouchingCuboids.h5m", min_mesh_size=0.1, max_mesh_size=100.0):
+        from cad_to_dagmc import CadToDagmc
+        import openmc
+
         assembly = self.cadquery_assembly()
+
         ctd = CadToDagmc()
         material_tags = [self.materials[0].name, self.materials[1].name]
         ctd.add_cadquery_object(assembly, material_tags=material_tags)


### PR DESCRIPTION
this means users without openmc but with cadquery can use the cad part of the code and vica versa