### PR TITLE
Adding materials to openmc.Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Activate the environment
 mamba activate new_env
 ```
 
-Install the dependencies
+Install the dependencies, if this fails to solve the enivornmet you could also try [installing OpenMC from source](https://docs.openmc.org/en/stable/quickinstall.html) which might be prefered.
 
 ```bash
 mamba install -y -c cadquery -c conda-forge moab gmsh python-gmsh cadquery=master "openmc=0.13.3=dagmc*nompi*"

--- a/examples/compare_csg_cad_circulartorus.py
+++ b/examples/compare_csg_cad_circulartorus.py
@@ -37,7 +37,6 @@ my_settings.source = my_source
 
 # making openmc.Model with CSG geometry
 csg_model = common_geometry_object.csg_model()
-csg_model.materials = my_materials
 csg_model.tallies = my_tallies
 csg_model.settings = my_settings
 
@@ -50,7 +49,6 @@ csg_result = f'CSG tally mean {csg_result.mean} std dev {csg_result.std_dev}'
 
 # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
 dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-dag_model.materials = my_materials
 dag_model.tallies = my_tallies
 dag_model.settings = my_settings
 

--- a/examples/compare_csg_cad_cuboid.py
+++ b/examples/compare_csg_cad_cuboid.py
@@ -33,7 +33,6 @@ my_settings.source = my_source
 
 # making openmc.Model with CSG geometry
 csg_model = common_geometry_object.csg_model()
-csg_model.materials = my_materials
 csg_model.tallies = my_tallies
 csg_model.settings = my_settings
 
@@ -46,7 +45,6 @@ csg_result = f'CSG tally mean {csg_result.mean} std dev {csg_result.std_dev}'
 
 # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a Cuboid
 dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-dag_model.materials = my_materials
 dag_model.tallies = my_tallies
 dag_model.settings = my_settings
 

--- a/examples/compare_csg_cad_cylinder.py
+++ b/examples/compare_csg_cad_cylinder.py
@@ -33,7 +33,6 @@ my_settings.source = my_source
 
 # making openmc.Model with CSG geometry
 csg_model = common_geometry_object.csg_model()
-csg_model.materials = my_materials
 csg_model.tallies = my_tallies
 csg_model.settings = my_settings
 
@@ -46,7 +45,6 @@ csg_result = f'CSG tally mean {csg_result.mean} std dev {csg_result.std_dev}'
 
 # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
 dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-dag_model.materials = my_materials
 dag_model.tallies = my_tallies
 dag_model.settings = my_settings
 

--- a/examples/compare_csg_cad_ellipticaltorus.py
+++ b/examples/compare_csg_cad_ellipticaltorus.py
@@ -38,7 +38,6 @@ my_settings.source = my_source
 
 # making openmc.Model with CSG geometry
 csg_model = common_geometry_object.csg_model()
-csg_model.materials = my_materials
 csg_model.tallies = my_tallies
 csg_model.settings = my_settings
 
@@ -51,7 +50,6 @@ csg_result = f'CSG tally mean {csg_result.mean} std dev {csg_result.std_dev}'
 
 # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
 dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-dag_model.materials = my_materials
 dag_model.tallies = my_tallies
 dag_model.settings = my_settings
 

--- a/examples/compare_csg_cad_nestedcylinder.py
+++ b/examples/compare_csg_cad_nestedcylinder.py
@@ -43,7 +43,6 @@ my_settings.source = my_source
 
 # making openmc.Model with CSG geometry
 csg_model = common_geometry_object.csg_model()
-csg_model.materials = my_materials
 csg_model.tallies = my_tallies
 csg_model.settings = my_settings
 
@@ -58,7 +57,6 @@ csg_result_mat_2_str = f'CSG tally mean {csg_result_mat_2.mean} std dev {csg_res
 
 # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
 dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-dag_model.materials = my_materials
 dag_model.tallies = my_tallies
 dag_model.settings = my_settings
 

--- a/examples/compare_csg_cad_nestedsphere.py
+++ b/examples/compare_csg_cad_nestedsphere.py
@@ -43,7 +43,6 @@ my_settings.source = my_source
 
 # making openmc.Model with CSG geometry
 csg_model = common_geometry_object.csg_model()
-csg_model.materials = my_materials
 csg_model.tallies = my_tallies
 csg_model.settings = my_settings
 
@@ -58,7 +57,6 @@ csg_result_mat_2_str = f'CSG tally mean {csg_result_mat_2.mean} std dev {csg_res
 
 # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
 dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-dag_model.materials = my_materials
 dag_model.tallies = my_tallies
 dag_model.settings = my_settings
 

--- a/examples/compare_csg_cad_sphere.py
+++ b/examples/compare_csg_cad_sphere.py
@@ -33,7 +33,6 @@ my_settings.source = my_source
 
 # making openmc.Model with CSG geometry
 csg_model = common_geometry_object.csg_model()
-csg_model.materials = my_materials
 csg_model.tallies = my_tallies
 csg_model.settings = my_settings
 
@@ -46,7 +45,6 @@ csg_result = f'CSG tally mean {csg_result.mean} std dev {csg_result.std_dev}'
 
 # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
 dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-dag_model.materials = my_materials
 dag_model.tallies = my_tallies
 dag_model.settings = my_settings
 

--- a/examples/compare_csg_cad_two_touching_cuboids.py
+++ b/examples/compare_csg_cad_two_touching_cuboids.py
@@ -42,7 +42,6 @@ my_settings.source = my_source
 
 # making openmc.Model with CSG geometry
 csg_model = common_geometry_object.csg_model()
-csg_model.materials = my_materials
 csg_model.tallies = my_tallies
 csg_model.settings = my_settings
 
@@ -57,7 +56,6 @@ csg_result_2 = f'CSG tally mat 2 mean {csg_result2.mean} std dev {csg_result2.st
 
 # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a TwoTouchingCuboids
 dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-dag_model.materials = my_materials
 dag_model.tallies = my_tallies
 dag_model.settings = my_settings
 

--- a/src/model_benchmark_zoo/circulartorus.py
+++ b/src/model_benchmark_zoo/circulartorus.py
@@ -14,7 +14,8 @@ class Circulartorus:
         cell = openmc.Cell(region=region)
         cell.fill = self.materials[0]
         geometry = openmc.Geometry([cell])
-        model = openmc.Model(geometry=geometry)
+        materials = openmc.Materials([self.materials[0]])
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model
 
     def cadquery_assembly(self):
@@ -41,7 +42,8 @@ class Circulartorus:
             max_mesh_size=max_mesh_size
         )
         universe = openmc.DAGMCUniverse(filename).bounded_universe()
+        materials = openmc.Materials([self.materials[0]])
         geometry = openmc.Geometry(universe)
 
-        model = openmc.Model(geometry=geometry)
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model

--- a/src/model_benchmark_zoo/cuboid.py
+++ b/src/model_benchmark_zoo/cuboid.py
@@ -20,7 +20,8 @@ class Cuboid:
         cell = openmc.Cell(region=region)
         cell.fill = self.materials[0]
         geometry = openmc.Geometry([cell])
-        model = openmc.Model(geometry=geometry)
+        materials = openmc.Materials([self.materials[0]])
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model
 
     def cadquery_assembly(self):
@@ -48,5 +49,6 @@ class Cuboid:
         )
         universe = openmc.DAGMCUniverse(filename).bounded_universe()
         geometry = openmc.Geometry(universe)
-        model = openmc.Model(geometry=geometry)
+        materials = openmc.Materials([self.materials[0]])
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model

--- a/src/model_benchmark_zoo/cylinder.py
+++ b/src/model_benchmark_zoo/cylinder.py
@@ -15,8 +15,9 @@ class Cylinder:
         region = -surface_1 & -surface_2 & +surface_3
         cell = openmc.Cell(region=region)
         cell.fill = self.materials[0]
+        materials = openmc.Materials([self.materials[0]])
         geometry = openmc.Geometry([cell])
-        model = openmc.Model(geometry=geometry)
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model
     
     def cadquery_assembly(self):
@@ -43,6 +44,7 @@ class Cylinder:
             max_mesh_size=max_mesh_size
         )
         universe = openmc.DAGMCUniverse(filename).bounded_universe()
+        materials = openmc.Materials([self.materials[0]])
         geometry = openmc.Geometry(universe)
-        model = openmc.Model(geometry=geometry)
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model

--- a/src/model_benchmark_zoo/ellipticaltorus.py
+++ b/src/model_benchmark_zoo/ellipticaltorus.py
@@ -17,8 +17,9 @@ class Ellipticaltorus:
         region = -surface
         cell = openmc.Cell(region=region)
         cell.fill = self.materials[0]
+        materials = openmc.Materials([self.materials[0]])
         geometry = openmc.Geometry([cell])
-        model = openmc.Model(geometry=geometry)
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model
 
     def cadquery_assembly(self):
@@ -47,7 +48,8 @@ class Ellipticaltorus:
             max_mesh_size=max_mesh_size
         )
         universe = openmc.DAGMCUniverse(filename).bounded_universe()
+        materials = openmc.Materials([self.materials[0]])
         geometry = openmc.Geometry(universe)
 
-        model = openmc.Model(geometry=geometry)
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model

--- a/src/model_benchmark_zoo/nestedcylinder.py
+++ b/src/model_benchmark_zoo/nestedcylinder.py
@@ -27,11 +27,13 @@ class NestedCylinder:
         region_1 = -surface_1 & -surface_2 & +surface_3
         region_2 = -surface_3 & -surface_4 & +surface_5
 
-        cell_1 = openmc.Cell(region=region_1 & ~ region_2)
-        cell_2 = openmc.Cell(region=region_2)
+        cell_1 = openmc.Cell(region=region_1 & ~ region_2, fill=self.materials[0])
+        cell_2 = openmc.Cell(region=region_2, fill=self.materials[1])
 
         geometry = openmc.Geometry([cell_1, cell_2])
-        model = openmc.Model(geometry=geometry)
+        materials = openmc.Materials([self.materials[0], self.materials[1]])
+        model = openmc.Model(geometry=geometry, materials=materials)
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model
 
     def cadquery_assembly(self):

--- a/src/model_benchmark_zoo/nestedcylinder.py
+++ b/src/model_benchmark_zoo/nestedcylinder.py
@@ -33,7 +33,6 @@ class NestedCylinder:
         geometry = openmc.Geometry([cell_1, cell_2])
         materials = openmc.Materials([self.materials[0], self.materials[1]])
         model = openmc.Model(geometry=geometry, materials=materials)
-        model = openmc.Model(geometry=geometry, materials=materials)
         return model
 
     def cadquery_assembly(self):
@@ -64,5 +63,6 @@ class NestedCylinder:
         )
         universe = openmc.DAGMCUniverse(filename).bounded_universe()
         geometry = openmc.Geometry(universe)
-        model = openmc.Model(geometry=geometry)
+        materials = openmc.Materials([self.materials[0], self.materials[1]])
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model

--- a/src/model_benchmark_zoo/nestedsphere.py
+++ b/src/model_benchmark_zoo/nestedsphere.py
@@ -17,7 +17,8 @@ class NestedSphere:
         cell2 = openmc.Cell(region=region2)
         cell2.fill = self.materials[1]
         geometry = openmc.Geometry([cell1, cell2])
-        model = openmc.Model(geometry=geometry)
+        materials = openmc.Materials([self.materials[0], self.materials[1]])
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model
 
     def cadquery_assembly(self):

--- a/src/model_benchmark_zoo/nestedsphere.py
+++ b/src/model_benchmark_zoo/nestedsphere.py
@@ -48,6 +48,7 @@ class NestedSphere:
             msh_filename='nestedshpere.msh'  # this arg allows the gmsh file to be written out
         )
         universe = openmc.DAGMCUniverse(filename).bounded_universe()
+        materials = openmc.Materials([self.materials[0], self.materials[1]])
         geometry = openmc.Geometry(universe)
-        model = openmc.Model(geometry=geometry)
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model

--- a/src/model_benchmark_zoo/sphere.py
+++ b/src/model_benchmark_zoo/sphere.py
@@ -12,7 +12,8 @@ class Sphere:
         cell = openmc.Cell(region=region)
         cell.fill = self.materials[0]
         geometry = openmc.Geometry([cell])
-        model = openmc.Model(geometry=geometry)
+        materials = openmc.Geometry([self.materials[0]])
+        model = openmc.Model(geometry=geometry, materials=materials)
         # TODO return openmc.model object
         return model
 
@@ -40,6 +41,7 @@ class Sphere:
             max_mesh_size=max_mesh_size
         )
         universe = openmc.DAGMCUniverse(filename).bounded_universe()
+        materials = openmc.Materials([self.materials[0]])
         geometry = openmc.Geometry(universe)
-        model = openmc.Model(geometry=geometry)
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model

--- a/src/model_benchmark_zoo/two_touching_cuboids.py
+++ b/src/model_benchmark_zoo/two_touching_cuboids.py
@@ -66,8 +66,9 @@ class TwoTouchingCuboids:
             msh_filename='TwoTouchingCuboids.msh'
         )
         universe = openmc.DAGMCUniverse(filename).bounded_universe()
+        materials = openmc.Materials([self.materials[0], self.materials[1]])
         geometry = openmc.Geometry(universe)
-        model = openmc.Model(geometry=geometry)
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model
 
     def dagmc_model_with_cad_to_openmc(self, filename="TwoTouchingCuboids.h5m"):
@@ -88,6 +89,7 @@ class TwoTouchingCuboids:
         )
 
         universe = openmc.DAGMCUniverse(filename, auto_geom_ids=True).bounded_universe()
+        materials = openmc.Materials([self.materials[0], self.materials[1]])
         geometry = openmc.Geometry(universe)
-        model = openmc.Model(geometry=geometry)
+        model = openmc.Model(geometry=geometry, materials=materials)
         return model

--- a/tests/test_cad_to_dagmc/test_csg_cad_circulartorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_circulartorus.py
@@ -39,7 +39,6 @@ def test_compare():
 
     # making openmc.Model with CSG geometry
     csg_model = common_geometry_object.csg_model()
-    csg_model.materials = my_materials
     csg_model.tallies = my_tallies
     csg_model.settings = my_settings
 
@@ -51,7 +50,6 @@ def test_compare():
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a circular torus
     dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-    dag_model.materials = my_materials
     dag_model.tallies = my_tallies
     dag_model.settings = my_settings
 

--- a/tests/test_cad_to_dagmc/test_csg_cad_cuboid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cuboid.py
@@ -35,7 +35,6 @@ def test_comparing():
 
     # making openmc.Model with CSG geometry
     csg_model = common_geometry_object.csg_model()
-    csg_model.materials = my_materials
     csg_model.tallies = my_tallies
     csg_model.settings = my_settings
 
@@ -47,7 +46,6 @@ def test_comparing():
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a Cuboid
     dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-    dag_model.materials = my_materials
     dag_model.tallies = my_tallies
     dag_model.settings = my_settings
 

--- a/tests/test_cad_to_dagmc/test_csg_cad_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cylinder.py
@@ -35,7 +35,6 @@ def test_compare():
 
     # making openmc.Model with CSG geometry
     csg_model = common_geometry_object.csg_model()
-    csg_model.materials = my_materials
     csg_model.tallies = my_tallies
     csg_model.settings = my_settings
 
@@ -47,7 +46,6 @@ def test_compare():
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a cylinder
     dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-    dag_model.materials = my_materials
     dag_model.tallies = my_tallies
     dag_model.settings = my_settings
 

--- a/tests/test_cad_to_dagmc/test_csg_cad_ellipticaltorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_ellipticaltorus.py
@@ -41,7 +41,6 @@ def test_compare():
 
     # making openmc.Model with CSG geometry
     csg_model = common_geometry_object.csg_model()
-    csg_model.materials = my_materials
     csg_model.tallies = my_tallies
     csg_model.settings = my_settings
 
@@ -53,7 +52,6 @@ def test_compare():
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a Ellipticaltorus
     dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-    dag_model.materials = my_materials
     dag_model.tallies = my_tallies
     dag_model.settings = my_settings
 

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedcylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedcylinder.py
@@ -45,7 +45,6 @@ def test_compare():
 
     # making openmc.Model with CSG geometry
     csg_model = common_geometry_object.csg_model()
-    csg_model.materials = my_materials
     csg_model.tallies = my_tallies
     csg_model.settings = my_settings
 
@@ -58,7 +57,6 @@ def test_compare():
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-    dag_model.materials = my_materials
     dag_model.tallies = my_tallies
     dag_model.settings = my_settings
 

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedsphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedsphere.py
@@ -45,7 +45,6 @@ def test_compare():
 
     # making openmc.Model with CSG geometry
     csg_model = common_geometry_object.csg_model()
-    csg_model.materials = my_materials
     csg_model.tallies = my_tallies
     csg_model.settings = my_settings
 
@@ -58,7 +57,6 @@ def test_compare():
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-    dag_model.materials = my_materials
     dag_model.tallies = my_tallies
     dag_model.settings = my_settings
 

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere.py
@@ -35,7 +35,6 @@ def test_compare():
 
     # making openmc.Model with CSG geometry
     csg_model = common_geometry_object.csg_model()
-    csg_model.materials = my_materials
     csg_model.tallies = my_tallies
     csg_model.settings = my_settings
 
@@ -47,7 +46,6 @@ def test_compare():
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
-    dag_model.materials = my_materials
     dag_model.tallies = my_tallies
     dag_model.settings = my_settings
 

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_touching_cuboids.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_touching_cuboids.py
@@ -44,7 +44,6 @@ def test_compare():
 
     # making openmc.Model with CSG geometry
     csg_model = common_geometry_object.csg_model()
-    csg_model.materials = my_materials
     csg_model.tallies = my_tallies
     csg_model.settings = my_settings
 
@@ -57,7 +56,6 @@ def test_compare():
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a TwoTouchingCuboids
     dag_model = common_geometry_object.dagmc_model_with_cad_to_dagmc(min_mesh_size=0.01, max_mesh_size=0.5)
-    dag_model.materials = my_materials
     dag_model.tallies = my_tallies
     dag_model.settings = my_settings
 


### PR DESCRIPTION
The classes can set the materials in the model so that the tests and example scripts don't have. This saves a few lines of code