### PR TITLE
remove commit version allowing ocp 7.7.2

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -4,7 +4,7 @@ runs:
     using: "composite"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: install dependencies
         shell: bash
@@ -20,7 +20,7 @@ runs:
           sudo apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev libosmesa6 libosmesa6-dev libgles2-mesa-dev libarchive-dev libpangocairo-1.0-0
           mamba activate
           mamba install -y -c conda-forge moab gmsh python-gmsh "openmc=0.14.0=dagmc*nompi*"
-          pip install git+https://github.com/CadQuery/cadquery.git@79e64e557e87d63b84c1c8a60c0df8e941a1a4a1
+          pip install git+https://github.com/CadQuery/cadquery.git
           pip install cad_to_dagmc openmc_data_downloader
           pip install --pre CAD_to_OpenMC
           openmc_data_downloader -l ENDFB-7.1-NNDC -i Fe56 Be9

--- a/README.md
+++ b/README.md
@@ -46,10 +46,15 @@ mamba install -y -c conda-forge moab gmsh python-gmsh "openmc=0.14.0=dagmc*nompi
 ```
 
 CadQuery should then be installed, here is the mamba command and the pip command.
-If the mamba command fails to solve the environment then try the pip command as this points to a specific version (before OCP 7.7.2 was made the default).
+
 ```bash
 mamba install -y -c cadquery cadquery=master
-pip install git+https://github.com/CadQuery/cadquery.git@79e64e557e87d63b84c1c8a60c0df8e941a1a4a1
+```
+
+If the mamba command fails to solve the environment then try this pip command.
+
+```bash
+pip install git+https://github.com/CadQuery/cadquery.git
 ```
 
 Then you can install the cad_to_dagmc package with ```pip```


### PR DESCRIPTION
cadquery install is currently pinned to a specific version. this cahnges the action so that we use the latest cq development version (which uses cadquery-ocp 7.7.2)