### PR TITLE
Oktavian model

### DIFF
--- a/examples/compare_csg_cad_oktavian.py
+++ b/examples/compare_csg_cad_oktavian.py
@@ -34,7 +34,7 @@ mat2.add_nuclide("Ni64", 0.00102786, "wo")
 my_materials = openmc.Materials([mat1, mat2])
 
 # geometry used in both simulations
-common_geometry_object = Oktavian(materials=my_materials)  # default sizes
+common_geometry_object = Oktavian(materials=my_materials)
 # just writing a CAD step file for visulisation
 common_geometry_object.export_stp_file("oktavian.stp")
 

--- a/examples/compare_csg_cad_oktavian.py
+++ b/examples/compare_csg_cad_oktavian.py
@@ -1,0 +1,87 @@
+from model_benchmark_zoo import Oktavian
+import openmc
+import math
+
+mat1 = openmc.Material(name='1')
+mat1.set_density("g/cm3", 1.223)
+mat1.add_nuclide("Al27", 0.9975488, "ao")
+mat1.add_nuclide("Si28", 0.001329808, "ao")
+mat1.add_nuclide("Si29", 6.752131e-05, "ao")
+mat1.add_nuclide("Si30", 4.450956e-05, "ao")
+mat1.add_nuclide("Fe54", 5.651123e-05, "ao")
+mat1.add_nuclide("Fe56", 0.0008871055, "ao")
+mat1.add_nuclide("Fe57", 2.048713e-05, "ao")
+mat1.add_nuclide("Fe58", 2.726461e-06, "ao")
+mat1.add_nuclide("Cu63", 2.938581e-05, "ao")
+mat1.add_nuclide("Cu65", 1.309765e-05, "ao")
+
+mat2 = openmc.Material(name='2')
+mat2.set_density("g/cm3", 7.824)
+mat2.add_nuclide("Cr50", 0.00803825, "wo")
+mat2.add_nuclide("Cr52", 0.15501, "wo")
+mat2.add_nuclide("Cr53", 0.0175768, "wo")
+mat2.add_nuclide("Cr54", 0.00437525, "wo")
+mat2.add_nuclide("Fe54", 0.0411488, "wo")
+mat2.add_nuclide("Fe56", 0.645948, "wo")
+mat2.add_nuclide("Fe57", 0.0149178, "wo")
+mat2.add_nuclide("Fe58", 0.00198528, "wo")
+mat2.add_nuclide("Ni58", 0.0755655, "wo")
+mat2.add_nuclide("Ni60", 0.0291075, "wo")
+mat2.add_nuclide("Ni61", 0.0012654, "wo")
+mat2.add_nuclide("Ni62", 0.00403374, "wo")
+mat2.add_nuclide("Ni64", 0.00102786, "wo")
+
+my_materials = openmc.Materials([mat1, mat2])
+
+# geometry used in both simulations
+common_geometry_object = Oktavian(materials=my_materials)  # default sizes
+# just writing a CAD step file for visulisation
+common_geometry_object.export_stp_file("oktavian.stp")
+
+mat1_filter = openmc.MaterialFilter(mat1)
+tally1 = openmc.Tally(name='mat1_flux_tally')
+tally1.filters = [mat1_filter]
+tally1.scores = ['flux']
+
+my_tallies = openmc.Tallies([tally1])
+
+my_settings = openmc.Settings()
+my_settings.batches = 10
+my_settings.inactive = 0
+my_settings.particles = 500
+my_settings.run_mode = 'fixed source'
+
+# Create a DT point source
+my_source = openmc.IndependentSource()
+my_source.space = openmc.stats.Point((0, 0, 0))
+my_source.angle = openmc.stats.Isotropic()
+my_source.energy = openmc.stats.Discrete([14e6], [1])
+my_settings.source = my_source
+
+# making openmc.Model with CSG geometry
+csg_model = common_geometry_object.csg_model()
+csg_model.tallies = my_tallies
+csg_model.settings = my_settings
+
+output_file_from_csg = csg_model.run()
+
+# extracting the tally result from the CSG simulation
+with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
+    csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+csg_result = f'CSG tally mean {csg_result.mean} std dev {csg_result.std_dev}'
+
+# making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
+dag_model = common_geometry_object.dagmc_model(min_mesh_size=0.01, max_mesh_size=0.5)
+dag_model.tallies = my_tallies
+dag_model.settings = my_settings
+
+output_file_from_cad = dag_model.run()
+
+# extracting the tally result from the DAGMC simulation
+with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
+    cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+cad_result = f'CAD tally mean {cad_result.mean} std dev {cad_result.std_dev}'
+
+# printing both tally results
+print(csg_result)
+print(cad_result)

--- a/src/model_benchmark_zoo/__init__.py
+++ b/src/model_benchmark_zoo/__init__.py
@@ -8,3 +8,4 @@ from .circulartorus import *
 from .nestedcylinder import *
 from .ellipticaltorus import *
 from .simpletokamak import *
+from .oktavian import *

--- a/src/model_benchmark_zoo/oktavian.py
+++ b/src/model_benchmark_zoo/oktavian.py
@@ -1,0 +1,68 @@
+from .utils import BaseCommonGeometryObject
+
+class oktavian(BaseCommonGeometryObject):
+
+    def csg_model(materials):
+        import openmc
+    
+        # surfaces
+        surf_1 = openmc.XCylinder(surface_id=1, y0=0.0, z0=0.0, r=5.55)
+        surf_2 = openmc.XCylinder(surface_id=2, y0=0.0, z0=0.0, r=5.75)
+        surf_3 = openmc.Sphere(surface_id=3, x0=0.0, y0=0.0, z0=0.0, r=10.0)
+        surf_4 = openmc.Sphere(surface_id=4, x0=0.0, y0=0.0, z0=0.0, r=10.2)
+        surf_5 = openmc.Sphere(surface_id=5, x0=0.0, y0=0.0, z0=0.0, r=19.75)
+        surf_6 = openmc.Sphere(surface_id=6, x0=0.0, y0=0.0, z0=0.0, r=19.95)
+        surf_7 = openmc.Sphere(surface_id=7, x0=0.0, y0=0.0, z0=0.0, r=100.0, boundary_type="vacuum")
+        surf_8 = openmc.XPlane(surface_id=8, x0=8.32)
+
+        # regions
+        region_1 = (-surf_3 & -surf_8) | (+surf_8 & -surf_1 & -surf_6)
+        region_2 = (+surf_3 & -surf_4 & -surf_8) | (+surf_8 & +surf_1 & -surf_2 & -surf_6)
+        region_3 = (+surf_4 & -surf_5 & -surf_8) | (+surf_8 & +surf_2 & -surf_5)
+        region_4 = (+surf_5 & -surf_6 & -surf_8) | (+surf_8 & +surf_2 & +surf_5 & -surf_6)
+        region_5 = +surf_6 & -surf_7
+
+        # cells
+        cell_1 = openmc.Cell(cell_id=1, region=region_1, fill=None)
+        cell_2 = openmc.Cell(cell_id=2, region=region_2, fill=materials[1])
+        cell_3 = openmc.Cell(cell_id=3, region=region_3, fill=materials[0])
+        cell_4 = openmc.Cell(cell_id=4, region=region_4, fill=materials[1])
+        cell_5 = openmc.Cell(cell_id=5, region=region_5, fill=None)
+
+        # create geometry instance
+        geometry = openmc.Geometry([cell_1, cell_2, cell_3, cell_4, cell_5])
+        my_materials = openmc.Materials([materials[0], materials[1]])
+        model = openmc.Model(geometry=geometry, materials=my_materials)
+        return model
+
+    def cadquery_assembly(self):
+        import cadquery as cq
+    
+        sphere1_radius = 10
+        cylinder_radius = 5.55
+        cylinder2_radius = cylinder_radius+0.2
+        sphere2_radius = sphere1_radius+0.2
+        sphere3_radius=sphere2_radius+9.55
+        sphere4_radius=sphere3_radius+0.2
+
+        sphere1 = cq.Workplane('XY').sphere(sphere1_radius)
+        sphere2 = cq.Workplane('XY').sphere(sphere2_radius)
+        sphere3 = cq.Workplane('XY').sphere(sphere3_radius)
+        sphere4 = cq.Workplane('XY').sphere(sphere4_radius)
+
+        cylinder1 = cq.Workplane('XY').cylinder(radius=cylinder_radius, height=300, centered=(0.5*cylinder_radius,10,0))
+        cylinder2 = cq.Workplane('XY').cylinder(radius=cylinder2_radius, height=300, centered=(0.5*cylinder2_radius,10,0))
+
+        cylinder2 = cylinder2.intersect(sphere4)
+        inner_void = sphere1.union(cylinder1)
+        inner_wall_sp = sphere2.cut(sphere1).cut(cylinder1)
+        inner_wall_cy = cylinder2.cut(cylinder1)
+        inner_wall = inner_wall_sp.union(inner_wall_cy)
+        mid_wall = sphere3.cut(sphere2).cut(cylinder2)
+        outer_wall =  sphere4.cut(sphere3).cut(cylinder2)
+        wall = outer_wall.union(inner_wall).cut(sphere1)
+
+        assembly = cq.Assembly()
+        assembly.add(wall)
+        assembly.add(mid_wall)
+        return assembly

--- a/src/model_benchmark_zoo/oktavian.py
+++ b/src/model_benchmark_zoo/oktavian.py
@@ -1,6 +1,6 @@
 from .utils import BaseCommonGeometryObject
 
-class oktavian(BaseCommonGeometryObject):
+class Oktavian(BaseCommonGeometryObject):
 
     def csg_model(materials):
         import openmc
@@ -38,6 +38,8 @@ class oktavian(BaseCommonGeometryObject):
     def cadquery_assembly(self):
         import cadquery as cq
     
+        assembly = cq.Assembly(name="oktavian")
+
         sphere1_radius = 10
         cylinder_radius = 5.55
         cylinder2_radius = cylinder_radius+0.2
@@ -62,7 +64,6 @@ class oktavian(BaseCommonGeometryObject):
         outer_wall =  sphere4.cut(sphere3).cut(cylinder2)
         wall = outer_wall.union(inner_wall).cut(sphere1)
 
-        assembly = cq.Assembly()
         assembly.add(wall)
         assembly.add(mid_wall)
         return assembly

--- a/tests/test_cad_to_dagmc/test_csg_cad_oktavian.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_oktavian.py
@@ -1,0 +1,96 @@
+from model_benchmark_zoo import Oktavian
+import openmc
+import math
+
+def test_compare():
+    # single material used in both simulations
+    mat1 = openmc.Material(name='1')
+    mat1.set_density("g/cm3", 1.223)
+    mat1.add_nuclide("Al27", 0.9975488, "ao")
+    mat1.add_nuclide("Si28", 0.001329808, "ao")
+    mat1.add_nuclide("Si29", 6.752131e-05, "ao")
+    mat1.add_nuclide("Si30", 4.450956e-05, "ao")
+    mat1.add_nuclide("Fe54", 5.651123e-05, "ao")
+    mat1.add_nuclide("Fe56", 0.0008871055, "ao")
+    mat1.add_nuclide("Fe57", 2.048713e-05, "ao")
+    mat1.add_nuclide("Fe58", 2.726461e-06, "ao")
+    mat1.add_nuclide("Cu63", 2.938581e-05, "ao")
+    mat1.add_nuclide("Cu65", 1.309765e-05, "ao")
+
+    mat2 = openmc.Material(name='2')
+    mat2.set_density("g/cm3", 7.824)
+    mat2.add_nuclide("Cr50", 0.00803825, "wo")
+    mat2.add_nuclide("Cr52", 0.15501, "wo")
+    mat2.add_nuclide("Cr53", 0.0175768, "wo")
+    mat2.add_nuclide("Cr54", 0.00437525, "wo")
+    mat2.add_nuclide("Fe54", 0.0411488, "wo")
+    mat2.add_nuclide("Fe56", 0.645948, "wo")
+    mat2.add_nuclide("Fe57", 0.0149178, "wo")
+    mat2.add_nuclide("Fe58", 0.00198528, "wo")
+    mat2.add_nuclide("Ni58", 0.0755655, "wo")
+    mat2.add_nuclide("Ni60", 0.0291075, "wo")
+    mat2.add_nuclide("Ni61", 0.0012654, "wo")
+    mat2.add_nuclide("Ni62", 0.00403374, "wo")
+    mat2.add_nuclide("Ni64", 0.00102786, "wo")
+
+    my_materials = openmc.Materials([mat1, mat2])
+
+    # geometry used in both simulations
+    common_geometry_object = Oktavian(materials=my_materials)
+
+    # just writing a CAD step file for visulisation
+    common_geometry_object.export_stp_file("oktavian.stp")
+
+    mat1_filter = openmc.MaterialFilter(mat1)
+    tally1 = openmc.Tally(name='mat1_flux_tally')
+    tally1.filters = [mat1_filter]
+    tally1.scores = ['flux']
+
+    my_tallies = openmc.Tallies([tally1])
+
+    my_settings = openmc.Settings()
+    my_settings.batches = 10
+    my_settings.inactive = 0
+    my_settings.particles = 500
+    my_settings.run_mode = 'fixed source'
+
+    # Create a DT point source
+    my_source = openmc.IndependentSource()
+    my_source.space = openmc.stats.Point((0, 0, 0))
+    my_source.angle = openmc.stats.Isotropic()
+    my_source.energy = openmc.stats.Discrete([14e6], [1])
+    my_settings.source = my_source
+
+    # making openmc.Model with CSG geometry
+    csg_model = common_geometry_object.csg_model()
+    csg_model.tallies = my_tallies
+    csg_model.settings = my_settings
+
+    output_file_from_csg = csg_model.run()
+
+    # extracting the tally result from the CSG simulation
+    with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
+        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
+    csg_result = f'CSG tally mean {csg_result.mean} std dev {csg_result.std_dev}'
+
+    # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
+    common_geometry_object.export_h5m_file_with_cad_to_dagmc(
+        h5m_filename='oktavian.h5m',
+        material_tags=['1', '2'],
+        min_mesh_size=0.01,
+        max_mesh_size=0.5
+    )
+    dag_model = common_geometry_object.dagmc_model(
+        h5m_filename='oktavian.h5m',
+        materials=[mat1, mat2]
+    )
+    dag_model.tallies = my_tallies
+    dag_model.settings = my_settings
+
+    output_file_from_cad = dag_model.run()
+
+    # extracting the tally result from the DAGMC simulation
+    with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
+        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
+
+    assert math.isclose(cad_result_mat_1.mean, csg_result_mat_1.mean)

--- a/tests/test_cad_to_openmc/test_csg_cad_oktavian.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_oktavian.py
@@ -1,0 +1,94 @@
+from model_benchmark_zoo import Oktavian
+import openmc
+import math
+
+def test_compare():
+    # single material used in both simulations
+    mat1 = openmc.Material(name='1')
+    mat1.set_density("g/cm3", 1.223)
+    mat1.add_nuclide("Al27", 0.9975488, "ao")
+    mat1.add_nuclide("Si28", 0.001329808, "ao")
+    mat1.add_nuclide("Si29", 6.752131e-05, "ao")
+    mat1.add_nuclide("Si30", 4.450956e-05, "ao")
+    mat1.add_nuclide("Fe54", 5.651123e-05, "ao")
+    mat1.add_nuclide("Fe56", 0.0008871055, "ao")
+    mat1.add_nuclide("Fe57", 2.048713e-05, "ao")
+    mat1.add_nuclide("Fe58", 2.726461e-06, "ao")
+    mat1.add_nuclide("Cu63", 2.938581e-05, "ao")
+    mat1.add_nuclide("Cu65", 1.309765e-05, "ao")
+
+    mat2 = openmc.Material(name='2')
+    mat2.set_density("g/cm3", 7.824)
+    mat2.add_nuclide("Cr50", 0.00803825, "wo")
+    mat2.add_nuclide("Cr52", 0.15501, "wo")
+    mat2.add_nuclide("Cr53", 0.0175768, "wo")
+    mat2.add_nuclide("Cr54", 0.00437525, "wo")
+    mat2.add_nuclide("Fe54", 0.0411488, "wo")
+    mat2.add_nuclide("Fe56", 0.645948, "wo")
+    mat2.add_nuclide("Fe57", 0.0149178, "wo")
+    mat2.add_nuclide("Fe58", 0.00198528, "wo")
+    mat2.add_nuclide("Ni58", 0.0755655, "wo")
+    mat2.add_nuclide("Ni60", 0.0291075, "wo")
+    mat2.add_nuclide("Ni61", 0.0012654, "wo")
+    mat2.add_nuclide("Ni62", 0.00403374, "wo")
+    mat2.add_nuclide("Ni64", 0.00102786, "wo")
+
+    my_materials = openmc.Materials([mat1, mat2])
+
+    # geometry used in both simulations
+    common_geometry_object = Oktavian(materials=my_materials)
+
+    # just writing a CAD step file for visulisation
+    common_geometry_object.export_stp_file("oktavian.stp")
+
+    mat1_filter = openmc.MaterialFilter(mat1)
+    tally1 = openmc.Tally(name='mat1_flux_tally')
+    tally1.filters = [mat1_filter]
+    tally1.scores = ['flux']
+
+    my_tallies = openmc.Tallies([tally1])
+
+    my_settings = openmc.Settings()
+    my_settings.batches = 10
+    my_settings.inactive = 0
+    my_settings.particles = 500
+    my_settings.run_mode = 'fixed source'
+
+    # Create a DT point source
+    my_source = openmc.IndependentSource()
+    my_source.space = openmc.stats.Point((0, 0, 0))
+    my_source.angle = openmc.stats.Isotropic()
+    my_source.energy = openmc.stats.Discrete([14e6], [1])
+    my_settings.source = my_source
+
+    # making openmc.Model with CSG geometry
+    csg_model = common_geometry_object.csg_model()
+    csg_model.tallies = my_tallies
+    csg_model.settings = my_settings
+
+    output_file_from_csg = csg_model.run()
+
+    # extracting the tally result from the CSG simulation
+    with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
+        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
+    csg_result = f'CSG tally mean {csg_result.mean} std dev {csg_result.std_dev}'
+
+    # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
+    common_geometry_object.export_h5m_file_with_cad_to_openmc(
+        h5m_filename='oktavian.h5m',
+        material_tags=['1', '2']
+    )
+    dag_model = common_geometry_object.dagmc_model(
+        h5m_filename='oktavian.h5m',
+        materials=[mat1, mat2]
+    )
+    dag_model.tallies = my_tallies
+    dag_model.settings = my_settings
+
+    output_file_from_cad = dag_model.run()
+
+    # extracting the tally result from the DAGMC simulation
+    with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
+        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
+
+    assert math.isclose(cad_result_mat_1.mean, csg_result_mat_1.mean)


### PR DESCRIPTION
This PR adds the Oktavian benchmark model to the `model_benchmark_zoo`, supporting both CSG and CAD representations.

Main additions:
- New geometry class `Oktavian` in `src/model_benchmark_zoo/oktavian.py`, implementing both `csg_model()` and `cadquery_assembly()` methods via the `BaseCommonGeometryObject` interface
- Example script `compare_csg_cad_oktavian.py` to compare the CSG and CAD versions of the model
- Test scripts for:
  - CAD to DAGMC
  - CAD to OpenMC