### PR TITLE
Add geometry for two tetrahedrons sharing a face

### DIFF
--- a/src/model_benchmark_zoo/__init__.py
+++ b/src/model_benchmark_zoo/__init__.py
@@ -10,3 +10,4 @@ from .ellipticaltorus import *
 from .simpletokamak import *
 from .oktavian import *
 from .tetrahedral import *
+from .two_tetrahedrons import *

--- a/src/model_benchmark_zoo/two_tetrahedrons.py
+++ b/src/model_benchmark_zoo/two_tetrahedrons.py
@@ -1,0 +1,85 @@
+from .utils import BaseCommonGeometryObject
+
+
+class TwoTetrahedrons(BaseCommonGeometryObject):
+    """
+    This geometry is composed of two tetrahedrons that share a face.
+    It is based on the single Tetrahedral geometry.
+    """
+
+    def __init__(
+        self,
+        length: float = 1.0,
+    ):
+        self.length = length
+
+    def csg_model(self, materials):
+        """
+        Creates a CSG model of two tetrahedrons sharing a face.
+
+        Args:
+            materials (list of openmc.Material): A list of two materials,
+                one for each tetrahedron.
+        """
+        import openmc
+
+        # Tet 1 planes
+        plane_x0 = openmc.XPlane(0)
+        plane_y0 = openmc.YPlane(0, boundary_type="vacuum")
+        plane_z0 = openmc.ZPlane(0, boundary_type="vacuum")
+        plane_1 = openmc.Plane(a=1, b=1, c=1, d=self.length, boundary_type="vacuum")
+
+        # Tet 2 planes
+        plane_2 = openmc.Plane(a=-1, b=1, c=1, d=self.length, boundary_type="vacuum")
+
+        # Tet 1 region
+        region1 = +plane_x0 & +plane_y0 & +plane_z0 & -plane_1
+
+        # Tet 2 region
+        region2 = -plane_x0 & +plane_y0 & +plane_z0 & -plane_2
+
+        cell1 = openmc.Cell(region=region1)
+        cell1.fill = materials[0]
+        cell2 = openmc.Cell(region=region2)
+        cell2.fill = materials[1]
+
+        my_materials = openmc.Materials(materials)
+        geometry = openmc.Geometry([cell1, cell2])
+        model = openmc.Model(geometry=geometry, materials=my_materials)
+        return model
+
+    def cadquery_assembly(self):
+        """
+        Creates a CAD model of two tetrahedrons sharing a face.
+        """
+        import cadquery as cq
+
+        # Vertices for the first tetrahedron
+        A = cq.Vector(0, 0, 0)
+        B = cq.Vector(self.length, 0, 0)
+        C = cq.Vector(0, self.length, 0)
+        D = cq.Vector(0, 0, self.length)
+
+        # Vertices for the second tetrahedron
+        B_prime = cq.Vector(-self.length, 0, 0)
+
+        # Create faces for the first tetrahedron
+        f1_1 = cq.Face.makeFromWires(cq.Wire.makePolygon([A, B, C, A]))
+        f1_2 = cq.Face.makeFromWires(cq.Wire.makePolygon([A, B, D, A]))
+        f1_3 = cq.Face.makeFromWires(cq.Wire.makePolygon([A, C, D, A]))
+        f1_4 = cq.Face.makeFromWires(cq.Wire.makePolygon([B, C, D, B]))
+        shell1 = cq.Shell.makeShell([f1_1, f1_2, f1_3, f1_4])
+        solid1 = cq.Solid.makeSolid(shell1)
+
+        # Create faces for the second tetrahedron
+        f2_1 = cq.Face.makeFromWires(cq.Wire.makePolygon([A, B_prime, C, A]))
+        f2_2 = cq.Face.makeFromWires(cq.Wire.makePolygon([A, B_prime, D, A]))
+        f2_3 = cq.Face.makeFromWires(cq.Wire.makePolygon([A, C, D, A]))
+        f2_4 = cq.Face.makeFromWires(cq.Wire.makePolygon([B_prime, C, D, B_prime]))
+        shell2 = cq.Shell.makeShell([f2_1, f2_2, f2_3, f2_4])
+        solid2 = cq.Solid.makeSolid(shell2)
+
+        assembly = cq.Assembly(name="two_tetrahedrons")
+        assembly.add(solid1)
+        assembly.add(solid2)
+        return assembly

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_tetrahedrons.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_tetrahedrons.py
@@ -1,0 +1,70 @@
+from model_benchmark_zoo import TwoTetrahedrons
+import openmc
+import math
+
+def test_compare_csg_and_cad():
+    # single material used in both simulations
+    mat1 = openmc.Material(name='1')
+    mat1.add_nuclide('Fe56', 1)
+    mat1.set_density('g/cm3', 1)
+
+    mat2 = openmc.Material(name='2')
+    mat2.add_nuclide('Fe56', 1)
+    mat2.set_density('g/cm3', 1)
+
+    # geometry used in both simulations
+    common_geometry_object = TwoTetrahedrons(length=10)
+    # just writing a CAD step file for visulisation
+    common_geometry_object.export_stp_file("two_tetrahedrons.stp")
+
+    mat_filter = openmc.MaterialFilter(mat1)
+    tally = openmc.Tally(name='mat1_flux_tally')
+    tally.filters = [mat_filter]
+    tally.scores = ['flux']
+    my_tallies = openmc.Tallies([tally])
+
+    my_settings = openmc.Settings()
+    my_settings.batches = 10
+    my_settings.inactive = 0
+    my_settings.particles = 500
+    my_settings.run_mode = 'fixed source'
+
+    # Create a DT point source
+    my_source = openmc.IndependentSource()
+    my_source.space = openmc.stats.Point((common_geometry_object.length/4,
+                                          common_geometry_object.length/4,
+                                          common_geometry_object.length/4))
+    my_source.angle = openmc.stats.Isotropic()
+    my_source.energy = openmc.stats.Discrete([14e6], [1])
+    my_settings.source = my_source
+
+    # making openmc.Model with CSG geometry
+    csg_model = common_geometry_object.csg_model(materials=[mat1, mat2])
+    csg_model.tallies = my_tallies
+    csg_model.settings = my_settings
+
+    output_file_from_csg = csg_model.run()
+
+    # extracting the tally result from the CSG simulation
+    with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
+        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+
+    # making openmc.Model with DAGMC geometry
+    common_geometry_object.export_h5m_file_with_cad_to_dagmc(
+        h5m_filename='two_tetrahedrons.h5m',
+        material_tags=['1', '2'],
+    )
+    dag_model = common_geometry_object.dagmc_model(
+        h5m_filename='two_tetrahedrons.h5m',
+        materials=[mat1, mat2]
+    )
+    dag_model.tallies = my_tallies
+    dag_model.settings = my_settings
+
+    output_file_from_cad = dag_model.run()
+
+    # extracting the tally result from the DAGMC simulation
+    with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
+        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+    
+    assert math.isclose(cad_result.mean, csg_result.mean)

--- a/tests/test_cad_to_openmc/test_csg_cad_two_tetrahedrons.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_two_tetrahedrons.py
@@ -1,0 +1,70 @@
+from model_benchmark_zoo import TwoTetrahedrons
+import openmc
+import math
+
+def test_compare_csg_and_cad():
+    # single material used in both simulations
+    mat1 = openmc.Material(name='1')
+    mat1.add_nuclide('Fe56', 1)
+    mat1.set_density('g/cm3', 1)
+
+    mat2 = openmc.Material(name='2')
+    mat2.add_nuclide('Fe56', 1)
+    mat2.set_density('g/cm3', 1)
+
+    # geometry used in both simulations
+    common_geometry_object = TwoTetrahedrons(length=10)
+    # just writing a CAD step file for visulisation
+    common_geometry_object.export_stp_file("two_tetrahedrons.stp")
+
+    mat_filter = openmc.MaterialFilter(mat1)
+    tally = openmc.Tally(name='mat1_flux_tally')
+    tally.filters = [mat_filter]
+    tally.scores = ['flux']
+    my_tallies = openmc.Tallies([tally])
+
+    my_settings = openmc.Settings()
+    my_settings.batches = 10
+    my_settings.inactive = 0
+    my_settings.particles = 500
+    my_settings.run_mode = 'fixed source'
+
+    # Create a DT point source
+    my_source = openmc.IndependentSource()
+    my_source.space = openmc.stats.Point((common_geometry_object.length/4,
+                                          common_geometry_object.length/4,
+                                          common_geometry_object.length/4))
+    my_source.angle = openmc.stats.Isotropic()
+    my_source.energy = openmc.stats.Discrete([14e6], [1])
+    my_settings.source = my_source
+
+    # making openmc.Model with CSG geometry
+    csg_model = common_geometry_object.csg_model(materials=[mat1, mat2])
+    csg_model.tallies = my_tallies
+    csg_model.settings = my_settings
+
+    output_file_from_csg = csg_model.run()
+
+    # extracting the tally result from the CSG simulation
+    with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
+        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+
+    # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
+    common_geometry_object.export_h5m_file_with_cad_to_openmc(
+        h5m_filename='two_tetrahedrons.h5m',
+        material_tags=['1', '2'],
+    )
+    dag_model = common_geometry_object.dagmc_model(
+        h5m_filename='two_tetrahedrons.h5m',
+        materials=[mat1, mat2]
+    )
+    dag_model.tallies = my_tallies
+    dag_model.settings = my_settings
+
+    output_file_from_cad = dag_model.run()
+
+    # extracting the tally result from the DAGMC simulation
+    with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
+        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+    
+    assert math.isclose(cad_result.mean, csg_result.mean)


### PR DESCRIPTION
Introduce a new geometry class for two tetrahedrons that share a face, along with corresponding CSG and CAD model generation methods. Include tests to compare results from both geometries.

Fixes #43