### PR TITLE
Rolled back OCCT layer changes and disabled clean to fix degenerate sphere issue

### DIFF
--- a/src/model_benchmark_zoo/overlapping_spheres.py
+++ b/src/model_benchmark_zoo/overlapping_spheres.py
@@ -38,21 +38,19 @@ class OverlappingSpheres(BaseCommonGeometryObject):
 
     def cadquery_assembly(self):
         import cadquery as cq
-        from OCP.BRepPrimAPI import BRepPrimAPI_MakeSphere
-        from OCP.BRepAlgoAPI import BRepAlgoAPI_Cut
-        from OCP.gp import gp_Pnt
 
         d = self.separation / 2
         r = self.radius
 
         assembly = cq.Assembly(name="overlapping_spheres")
 
-        sphere1_shape = BRepPrimAPI_MakeSphere(gp_Pnt(-d, 0, 0), r).Shape()
-        sphere2_shape = BRepPrimAPI_MakeSphere(gp_Pnt(d, 0, 0), r).Shape()
+        z_dir = cq.Vector(0, 0, 1)
+        solid1 = cq.Solid.makeSphere(r, cq.Vector(-d, 0, 0), z_dir, -90, 90)
+        assembly.add(cq.Workplane().add(solid1))
 
-        assembly.add(cq.Workplane().add(cq.Solid(sphere1_shape)))
-
-        crescent_shape = BRepAlgoAPI_Cut(sphere2_shape, sphere1_shape).Shape()
-        assembly.add(cq.Workplane().add(cq.Solid(crescent_shape)))
+        solid2 = cq.Solid.makeSphere(r, cq.Vector(d, 0, 0), z_dir, -90, 90)
+        solid1_for_cut = cq.Solid.makeSphere(r, cq.Vector(-d, 0, 0), z_dir, -90, 90)
+        crescent = cq.Workplane().add(solid2).cut(cq.Workplane().add(solid1_for_cut), clean=False)
+        assembly.add(crescent)
 
         return assembly

--- a/src/model_benchmark_zoo/overlapping_spheres.py
+++ b/src/model_benchmark_zoo/overlapping_spheres.py
@@ -50,7 +50,7 @@ class OverlappingSpheres(BaseCommonGeometryObject):
 
         solid2 = cq.Solid.makeSphere(r, cq.Vector(d, 0, 0), z_dir, -90, 90)
         solid1_for_cut = cq.Solid.makeSphere(r, cq.Vector(-d, 0, 0), z_dir, -90, 90)
-        crescent = cq.Workplane().add(solid2).cut(cq.Workplane().add(solid1_for_cut), clean=True)
+        crescent = cq.Workplane().add(solid2).cut(cq.Workplane().add(solid1_for_cut), clean=False)
         assembly.add(crescent)
 
         return assembly

--- a/src/model_benchmark_zoo/overlapping_spheres.py
+++ b/src/model_benchmark_zoo/overlapping_spheres.py
@@ -50,7 +50,7 @@ class OverlappingSpheres(BaseCommonGeometryObject):
 
         solid2 = cq.Solid.makeSphere(r, cq.Vector(d, 0, 0), z_dir, -90, 90)
         solid1_for_cut = cq.Solid.makeSphere(r, cq.Vector(-d, 0, 0), z_dir, -90, 90)
-        crescent = cq.Workplane().add(solid2).cut(cq.Workplane().add(solid1_for_cut), clean=False)
+        crescent = cq.Workplane().add(solid2).cut(cq.Workplane().add(solid1_for_cut), clean=True)
         assembly.add(crescent)
 
         return assembly


### PR DESCRIPTION
@shimwell I think this is the fix for the overlapping spheres that @adam-urbanczyk suggested on the CadQuery issue [here](https://github.com/CadQuery/cadquery/issues/2020#issuecomment-4148749503).

I am not able to test this PR properly because with a fresh local Python 3.13 environment (Debian 13, AMD64), the overlapping spheres test succeeds both with and without disabling the clean. Below is a listing of my local environment.

```
$ pip list
Package                     Version
--------------------------- ---------------------
aiohappyeyeballs            2.6.1
aiohttp                     3.13.4
aiosignal                   1.4.0
asttokens                   3.0.1
attrs                       26.1.0
cad_to_dagmc                0.11.5
cadquery                    2.7.0
cadquery_direct_mesh_plugin 0.2.0
cadquery-ocp                7.8.1.1.post1
cadquery-ocp-proxy          7.9.3.1
cadquery_vtk                9.3.1
casadi                      3.7.2
contourpy                   1.3.3
cycler                      0.12.1
decorator                   5.2.1
endf                        0.1.12
executing                   2.2.1
ezdxf                       1.4.3
fonttools                   4.62.1
frozenlist                  1.8.0
gmsh                        4.15.2
h5py                        3.16.0
idna                        3.11
iniconfig                   2.3.0
ipython                     9.12.0
ipython_pygments_lexers     1.1.1
jedi                        0.19.2
kiwisolver                  1.5.0
lxml                        6.0.2
matplotlib                  3.10.8
matplotlib-inline           0.2.1
MOAB                        5.5.1
model_benchmark_zoo         0.1.dev288+gd139c1b4f
more-itertools              10.8.0
msgpack                     1.1.2
multidict                   6.7.1
multimethod                 1.12
networkx                    3.6.1
nlopt                       2.10.0
numpy                       2.4.4
openmc                      0.15.3
openmc_data_downloader      0.6.1
packaging                   26.0
pandas                      3.0.1
parso                       0.8.6
path                        17.1.1
pexpect                     4.9.0
pillow                      12.1.1
pip                         25.1.1
pluggy                      1.6.0
prompt_toolkit              3.0.52
propcache                   0.4.1
ptyprocess                  0.7.0
pure_eval                   0.2.3
py                          1.11.0
Pygments                    2.20.0
pyparsing                   3.3.2
pytest                      9.0.2
python-dateutil             2.9.0.post0
PyYAML                      6.0.3
retry                       0.9.2
runtype                     0.5.3
scipy                       1.17.1
six                         1.17.0
stack-data                  0.6.3
traitlets                   5.14.3
trame                       3.12.0
trame-client                3.11.4
trame-common                1.1.3
trame-components            2.5.0
trame-server                3.10.0
trame-vtk                   2.11.6
trame-vuetify               3.2.1
trimesh                     4.11.5
typing_extensions           4.15.0
uncertainties               3.2.3
vtk                         9.5.2
wcwidth                     0.6.0
wslink                      2.5.6
yarl                        1.23.0
```

