### PR TITLE
Make the CSG vs CAD comparison tests actually compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The repository then grew into a way to test my DAGMC geometry making package [ca
 
 ## Models
 
-The table below lists all 56 models with details of each model. The combined collection covers a significant number of CAD meshing challenges, but feel free to make a pull request if there are more edge cases to cover.
+The table below lists all 55 models with details of each model. The combined collection covers a significant number of CAD meshing challenges, but feel free to make a pull request if there are more edge cases to cover.
   
 | Model | Description | Materials | Meshing challenge |
 |---|---|---|---|
@@ -64,7 +64,7 @@ The table below lists all 56 models with details of each model. The combined col
 | <p align="center"><img src="images/three_touching_cuboids.png" width="100"></p> | Three touching cuboids | 3 | Multi-body imprinting at T-shaped shared faces; triple-edge junction |
 | <p align="center"><img src="images/nestedcylinder.png" width="100"></p> | Nested cylinders | 2 | Concentric cylindrical shells; conformal meshing at shared curved interfaces |
 | <p align="center"><img src="images/annular_sector.png" alt="Annular sector" width="100"></p> | Annular sector | 1 | Wedge slice of a cylindrical shell; curved surfaces meeting angled cut planes |
-| <p align="center"><img src="images/stepped_cylinder.png" alt="Stepped cylinder" width="100"></p> | Stepped cylinder | 1 | Abrupt radius change at step; mesh grading at cylindrical-to-planar transition |
+| <p align="center"><img src="images/stepped_cylinder.png" alt="Stepped cylinder" width="100"></p> | Stepped cylinder | 2 | Abrupt radius change at step; imprinting of a contact patch strictly interior to the larger face |
 | <p align="center"><img src="images/cone.png" alt="Cone" width="100"></p> | Cone | 1 | Degenerate apex where surface converges to a point; element collapse at tip |
 | <p align="center"><img src="images/pyramid.png" alt="Pyramid" width="100"></p> | Pyramid | 1 | Four flat faces converging to a degenerate apex point; element collapse at tip on planar faces |
 | <p align="center"><img src="images/two_tetrahedrons.png" width="100"></p> | Two tetrahedrons in contact | 2 | Shared triangular face with acute dihedral angles at all edges |

--- a/examples/compare_csg_cad_stepped_cylinder.py
+++ b/examples/compare_csg_cad_stepped_cylinder.py
@@ -46,7 +46,7 @@ csg_result = f'CSG tally mean {csg_result.mean.flatten()[0]} std dev {csg_result
 # making openmc.Model with DAGMC geometry
 common_geometry_object.export_h5m_file_with_cad_to_dagmc(
     filename='stepped_cylinder.h5m',
-    material_tags=['1'],
+    material_tags=['1', '1'],
     min_mesh_size=0.01,
     max_mesh_size=0.5
 )

--- a/src/model_benchmark_zoo/blanket_module.py
+++ b/src/model_benchmark_zoo/blanket_module.py
@@ -58,18 +58,21 @@ class BlanketModule(BaseCommonGeometryObject):
         ih = oh - 2 * wt
         id_ = od - 2 * wt
 
-        # Channel cylinder (along Y axis)
-        channel = cq.Workplane("XZ").cylinder(id_, cr)
-        assembly.add(channel)
+        # Solids are added in the same order as the materials in csg_model, as
+        # cad_to_dagmc assigns material_tags[i] to the i-th solid of the assembly.
+
+        # Wall: outer box minus inner box
+        outer_box = cq.Workplane("XY").box(ow, od, oh)
+        wall = outer_box.cut(cq.Workplane("XY").box(iw, id_, ih))
+        assembly.add(wall)
 
         # Breeder: inner box minus channel
         inner_box = cq.Workplane("XY").box(iw, id_, ih)
         breeder = inner_box.cut(cq.Workplane("XZ").cylinder(id_, cr))
         assembly.add(breeder)
 
-        # Wall: outer box minus inner box
-        outer_box = cq.Workplane("XY").box(ow, od, oh)
-        wall = outer_box.cut(cq.Workplane("XY").box(iw, id_, ih))
-        assembly.add(wall)
+        # Channel cylinder (along Y axis)
+        channel = cq.Workplane("XZ").cylinder(id_, cr)
+        assembly.add(channel)
 
         return assembly

--- a/src/model_benchmark_zoo/comparison.py
+++ b/src/model_benchmark_zoo/comparison.py
@@ -1,0 +1,90 @@
+"""Comparison of CAD (DAGMC) tally results against their CSG reference.
+
+Both the CSG and the CAD run of a model write ``statepoint.10.h5`` into the working
+directory, and OpenMC reads tally results lazily from that file. A tally handle taken
+from the first statepoint therefore returns the second run's numbers once the file has
+been overwritten, which silently turns a comparison into a self-comparison. Use
+:func:`read_tally` to read the values while the statepoint is still open.
+"""
+
+import math
+from typing import NamedTuple
+
+#: Largest relative difference tolerated between the CAD and CSG means. The CAD
+#: geometry is faceted before transport, so a small systematic difference against the
+#: analytic CSG surfaces is expected and does not indicate a broken model.
+RELATIVE_TOLERANCE = 0.02
+
+#: Largest difference tolerated in units of the combined Monte Carlo uncertainty.
+SIGMA_TOLERANCE = 3.0
+
+
+class TallyResult(NamedTuple):
+    """A tally mean and its standard deviation, already read from the statepoint."""
+
+    mean: float
+    std_dev: float
+
+
+def read_tally(statepoint, name: str, index: int = 0) -> TallyResult:
+    """Read a named tally's mean and standard deviation from an open statepoint.
+
+    Args:
+        statepoint: an open ``openmc.StatePoint``.
+        name: name of the tally to read.
+        index: index into the flattened tally results.
+
+    Returns:
+        The mean and standard deviation as plain floats, read eagerly so that they
+        cannot later be re-read from a statepoint file that another run has replaced.
+    """
+    tally = statepoint.get_tally(name=name)
+    return TallyResult(
+        float(tally.mean.flatten()[index]),
+        float(tally.std_dev.flatten()[index]),
+    )
+
+
+def assert_tally_agreement(
+    cad: TallyResult,
+    csg: TallyResult,
+    relative_tolerance: float = RELATIVE_TOLERANCE,
+    sigma_tolerance: float = SIGMA_TOLERANCE,
+) -> None:
+    """Assert that a CAD tally agrees with its CSG reference.
+
+    Two independent checks are applied and both must pass:
+
+    1. Relative: the means agree to within ``relative_tolerance``. This caps the
+       systematic difference introduced by faceting the CAD surfaces.
+    2. Statistical: the means agree to within ``sigma_tolerance`` combined standard
+       deviations. This catches a difference that is small in relative terms but far
+       outside the Monte Carlo uncertainty of the two runs.
+
+    Args:
+        cad: result from the CAD (DAGMC) run.
+        csg: result from the CSG run.
+        relative_tolerance: largest permitted relative difference.
+        sigma_tolerance: largest permitted difference in combined standard deviations.
+
+    Raises:
+        AssertionError: if either check fails.
+    """
+    difference = abs(cad.mean - csg.mean)
+    combined_sigma = math.sqrt(cad.std_dev**2 + csg.std_dev**2)
+
+    if difference == 0:
+        return
+
+    relative = difference / abs(csg.mean) if csg.mean else math.inf
+    sigmas = difference / combined_sigma if combined_sigma else math.inf
+
+    detail = (
+        f"cad={cad.mean:.6g} +/- {cad.std_dev:.3g}, "
+        f"csg={csg.mean:.6g} +/- {csg.std_dev:.3g}, "
+        f"relative difference {relative:.3%} (limit {relative_tolerance:.3%}), "
+        f"{sigmas:.2f} combined sigma (limit {sigma_tolerance})"
+    )
+
+    assert relative <= relative_tolerance, f"CAD and CSG differ systematically: {detail}"
+    assert sigmas <= sigma_tolerance, f"CAD and CSG are statistically inconsistent: {detail}"

--- a/src/model_benchmark_zoo/divertor_monoblock.py
+++ b/src/model_benchmark_zoo/divertor_monoblock.py
@@ -48,15 +48,18 @@ class DivertorMonoblock(BaseCommonGeometryObject):
         ro = self.pipe_outer_radius
         ri = self.pipe_inner_radius
 
-        # Pipe wall (annular, along Y axis)
-        outer_pipe = cq.Workplane("XZ").cylinder(d, ro)
-        inner_pipe = cq.Workplane("XZ").cylinder(d, ri)
-        pipe_wall = outer_pipe.cut(inner_pipe)
-        assembly.add(pipe_wall)
+        # Solids are added in the same order as the materials in csg_model, as
+        # cad_to_dagmc assigns material_tags[i] to the i-th solid of the assembly.
 
         # Block minus outer pipe
         block = cq.Workplane("XY").box(w, d, h)
         block_with_hole = block.cut(cq.Workplane("XZ").cylinder(d, ro))
         assembly.add(block_with_hole)
+
+        # Pipe wall (annular, along Y axis)
+        outer_pipe = cq.Workplane("XZ").cylinder(d, ro)
+        inner_pipe = cq.Workplane("XZ").cylinder(d, ri)
+        pipe_wall = outer_pipe.cut(inner_pipe)
+        assembly.add(pipe_wall)
 
         return assembly

--- a/src/model_benchmark_zoo/stepped_cylinder.py
+++ b/src/model_benchmark_zoo/stepped_cylinder.py
@@ -51,8 +51,13 @@ class SteppedCylinder(BaseCommonGeometryObject):
         upper = cq.Solid.makeCylinder(
             rs, h / 2, pnt=cq.Vector(0, 0, 0), dir=cq.Vector(0, 0, 1)
         )
-        result = cq.Workplane().add(lower).add(upper).combine()
 
+        # Kept as two separate solids rather than fused with combine(), so that
+        # the step exercises imprinting of a contact patch that is strictly
+        # interior to the larger face: the r=small_radius disc lands inside the
+        # r=large_radius disc with no shared boundary edge. Fusing the two
+        # cylinders would remove that interface entirely.
         assembly = cq.Assembly(name="stepped_cylinder")
-        assembly.add(result)
+        assembly.add(cq.Workplane().add(lower))
+        assembly.add(cq.Workplane().add(upper))
         return assembly

--- a/tests/test_cad_to_dagmc/test_csg_cad_annular_sector.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_annular_sector.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import AnnularSector
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_blanket_module.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_blanket_module.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import BlanketModule
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -61,9 +61,9 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='blanket_module.h5m',
@@ -80,10 +80,10 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0].flatten()[0], csg_result_mat_3.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)

--- a/tests/test_cad_to_dagmc/test_csg_cad_box_with_spherical_cavity.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_box_with_spherical_cavity.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import BoxWithSphericalCavity
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a box with spherical cavity
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_capsule.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_capsule.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Capsule
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_chamfered_box.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_chamfered_box.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ChamferedBox
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -42,7 +42,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='chamfered_box.h5m',
@@ -59,6 +59,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_circulartorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_circulartorus.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Circulartorus
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import numpy as np
 import pytest
 
@@ -52,7 +52,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a circular torus
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -71,7 +71,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)
 

--- a/tests/test_cad_to_dagmc/test_csg_cad_cladded_plate.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cladded_plate.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import CladdedPlate
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -61,9 +61,9 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='cladded_plate.h5m',
@@ -80,10 +80,10 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0].flatten()[0], csg_result_mat_3.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)

--- a/tests/test_cad_to_dagmc/test_csg_cad_concentric_cylinders.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_concentric_cylinders.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ConcentricCylinders
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -61,9 +61,9 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='concentric_cylinders.h5m',
@@ -80,10 +80,10 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0].flatten()[0], csg_result_mat_3.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)

--- a/tests/test_cad_to_dagmc/test_csg_cad_cone.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cone.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Cone
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -43,7 +43,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='cone.h5m',
@@ -60,6 +60,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_cross_junction.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cross_junction.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import CrossJunction
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -52,8 +52,8 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='cross_junction.h5m',
@@ -70,8 +70,8 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_cubic_lattice.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cubic_lattice.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import CubicLattice
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -52,8 +52,8 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='cubic_lattice.h5m',
@@ -70,8 +70,8 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_cuboid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cuboid.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Cuboid
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a Cuboid
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,7 +67,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)
 

--- a/tests/test_cad_to_dagmc/test_csg_cad_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cylinder.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Cylinder
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a cylinder
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,7 +67,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)
 

--- a/tests/test_cad_to_dagmc/test_csg_cad_cylinder_in_box.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cylinder_in_box.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import CylinderInBox
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -52,8 +52,8 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='cylinder_in_box.h5m',
@@ -70,8 +70,8 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_cylindrical_intersection.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cylindrical_intersection.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import CylindricalIntersection
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a CylindricalIntersection
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_divertor_monoblock.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_divertor_monoblock.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import DivertorMonoblock
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -52,8 +52,8 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='divertor_monoblock.h5m',
@@ -70,8 +70,8 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_eccentric_nested_cylinders.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_eccentric_nested_cylinders.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import EccentricNestedCylinders
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -52,8 +52,8 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='eccentric_nested_cylinders.h5m',
@@ -70,8 +70,8 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_ellipsoid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_ellipsoid.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Ellipsoid
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_elliptic_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_elliptic_cylinder.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo.elliptic_cylinder import EllipticCylinder
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_ellipticaltorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_ellipticaltorus.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Ellipticaltorus
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import numpy as np
 import pytest
 
@@ -54,7 +54,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a Ellipticaltorus
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -73,6 +73,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_fuel_pin_cell.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_fuel_pin_cell.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import FuelPinCell
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -61,9 +61,9 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='fuel_pin_cell.h5m',
@@ -80,10 +80,10 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0].flatten()[0], csg_result_mat_3.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)

--- a/tests/test_cad_to_dagmc/test_csg_cad_hemisphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hemisphere.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Hemisphere
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_lattice_cell.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_lattice_cell.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import HexagonalLatticeCell
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -52,8 +52,8 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='hexagonal_lattice_cell.h5m',
@@ -70,8 +70,8 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_prism.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_prism.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import HexagonalPrism
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -42,7 +42,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='hexagonal_prism.h5m',
@@ -59,6 +59,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_hyperboloid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hyperboloid.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Hyperboloid
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_l_shaped.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_l_shaped.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import LShaped
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -43,7 +43,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='l_shaped.h5m',
@@ -60,6 +60,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedcylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedcylinder.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import NestedCylinder
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -58,8 +58,8 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -78,8 +78,8 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedsphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedsphere.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import NestedSphere
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -58,8 +58,8 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -78,8 +78,8 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedtorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedtorus.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Nestedtorus
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import numpy as np
 import pytest
 
@@ -66,7 +66,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="flux_tally")
+        csg_result = read_tally(sp_from_csg, "flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -85,6 +85,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="flux_tally")
+        cad_result = read_tally(sp_from_cad, "flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0], rel_tol=0.05)
+    assert_tally_agreement(cad_result, csg_result, relative_tolerance=0.05)

--- a/tests/test_cad_to_dagmc/test_csg_cad_ogive.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_ogive.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Ogive
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_oktavian.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_oktavian.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Oktavian
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -56,7 +56,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -75,6 +75,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
         
-    assert math.isclose(float(cad_result_mat_1.mean.flatten()[0].flatten()[0]), float(csg_result_mat_1.mean.flatten()[0].flatten()[0]), rel_tol=0.01)
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1, relative_tolerance=0.01)

--- a/tests/test_cad_to_dagmc/test_csg_cad_overlapping_spheres.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_overlapping_spheres.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import OverlappingSpheres
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.001,
@@ -52,8 +52,8 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='overlapping_spheres.h5m',
@@ -70,8 +70,8 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_paraboloid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_paraboloid.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Paraboloid
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_pebble_bed_cell.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pebble_bed_cell.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import PebbleBedCell
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -70,10 +70,10 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
-        csg_result_mat_4 = sp_from_csg.get_tally(name="mat4_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
+        csg_result_mat_4 = read_tally(sp_from_csg, "mat4_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='pebble_bed_cell.h5m',
@@ -90,12 +90,12 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
-        cad_result_mat_4 = sp_from_cad.get_tally(name="mat4_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
+        cad_result_mat_4 = read_tally(sp_from_cad, "mat4_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0].flatten()[0], csg_result_mat_3.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_4.mean.flatten()[0].flatten()[0], csg_result_mat_4.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)
+    assert_tally_agreement(cad_result_mat_4, csg_result_mat_4)

--- a/tests/test_cad_to_dagmc/test_csg_cad_pipe.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pipe.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Pipe
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_pipe_elbow.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pipe_elbow.py
@@ -1,4 +1,5 @@
 from model_benchmark_zoo import PipeElbow
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import math
 import pytest
@@ -42,7 +43,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='pipe_elbow.h5m',
@@ -59,6 +60,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_pyramid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pyramid.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Pyramid
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -42,7 +42,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='pyramid.h5m',
@@ -59,6 +59,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_simple_tokamak.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_simple_tokamak.py
@@ -1,4 +1,5 @@
 from model_benchmark_zoo import SimpleTokamak
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import math
 import pytest
@@ -63,8 +64,8 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='simpletokamak.h5m',
@@ -80,8 +81,8 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0], rel_tol=0.01)
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0], rel_tol=0.01)
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1, relative_tolerance=0.01)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2, relative_tolerance=0.01)

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Sphere
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,7 +67,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)
 

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere_in_box.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere_in_box.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import SphereInBox
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -52,8 +52,8 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='sphere_in_box.h5m',
@@ -70,8 +70,8 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_cylindrical_hole.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_cylindrical_hole.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import SphereWithCylindricalHole
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere with cylindrical hole
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_multiple_holes.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_multiple_holes.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import SphereWithMultipleHoles
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -42,7 +42,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='sphere_with_multiple_holes.h5m',
@@ -59,6 +59,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_stepped_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_stepped_cylinder.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import SteppedCylinder
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -42,11 +42,11 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='stepped_cylinder.h5m',
-        material_tags=['1'],
+        material_tags=['1', '1'],
         **kwargs
     )
     dag_model = common_geometry_object.dagmc_model(
@@ -59,6 +59,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_t_junction.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_t_junction.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import TJunction
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -52,8 +52,8 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='t_junction.h5m',
@@ -70,8 +70,8 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_tetrahedral.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_tetrahedral.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Tetrahedral
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -49,7 +49,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to minimise number of triangles
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -68,6 +68,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_gap.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_gap.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ThinGap
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -56,8 +56,8 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a ThinGap
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -76,8 +76,8 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result1.mean.flatten()[0].flatten()[0], csg_result1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result2.mean.flatten()[0].flatten()[0], csg_result2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result1, csg_result1)
+    assert_tally_agreement(cad_result2, csg_result2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_plate.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_plate.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ThinPlate
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -42,7 +42,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='thin_plate.h5m',
@@ -59,6 +59,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_cylinder.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ThinWalledCylinder
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -42,7 +42,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='thin_walled_cylinder.h5m',
@@ -59,6 +59,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_sphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_sphere.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ThinWalledSphere
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -42,7 +42,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='thin_walled_sphere.h5m',
@@ -59,6 +59,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_three_touching_cuboids.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_three_touching_cuboids.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ThreeTouchingCuboids
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -67,9 +67,9 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -88,10 +88,10 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0].flatten()[0], csg_result_mat_1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0].flatten()[0], csg_result_mat_2.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0].flatten()[0], csg_result_mat_3.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)

--- a/tests/test_cad_to_dagmc/test_csg_cad_toroidal_sector.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_toroidal_sector.py
@@ -1,4 +1,5 @@
 from model_benchmark_zoo import ToroidalSector
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import math
 import pytest
@@ -42,7 +43,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='toroidal_sector.h5m',
@@ -59,6 +60,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_truncated_cone.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_truncated_cone.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import TruncatedCone
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -48,7 +48,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -67,6 +67,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_tetrahedrons.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_tetrahedrons.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import TwoTetrahedrons
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -54,7 +54,7 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -73,6 +73,6 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_touching_cuboids.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_touching_cuboids.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import TwoTouchingCuboids
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -56,8 +56,8 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a TwoTouchingCuboids
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -76,8 +76,8 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result2 = read_tally(sp_from_cad, "mat2_flux_tally")
  
-    assert math.isclose(cad_result1.mean.flatten()[0].flatten()[0], csg_result1.mean.flatten()[0].flatten()[0])
-    assert math.isclose(cad_result2.mean.flatten()[0].flatten()[0], csg_result2.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result1, csg_result1)
+    assert_tally_agreement(cad_result2, csg_result2)

--- a/tests/test_cad_to_dagmc/test_csg_cad_wedge.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_wedge.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Wedge
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import pytest
 
 kwargs_options = [{'min_mesh_size': 0.01,
@@ -43,7 +43,7 @@ def test_compare(kwargs):
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
         filename='wedge.h5m',
@@ -60,6 +60,6 @@ def test_compare(kwargs):
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0].flatten()[0], csg_result.mean.flatten()[0].flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_annular_sector.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_annular_sector.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import AnnularSector
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_blanket_module.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_blanket_module.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import BlanketModule
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -54,9 +54,9 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='blanket_module.h5m',
@@ -72,10 +72,10 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0], csg_result_mat_3.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)

--- a/tests/test_cad_to_openmc/test_csg_cad_box_with_spherical_cavity.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_box_with_spherical_cavity.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import BoxWithSphericalCavity
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_capsule.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_capsule.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Capsule
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_chamfered_box.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_chamfered_box.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ChamferedBox
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -35,7 +35,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='chamfered_box.h5m',
@@ -51,6 +51,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_circulartorus.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_circulartorus.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Circulartorus
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import numpy as np
 def test_compare():
     # single material used in both simulations
@@ -45,7 +45,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a circular torus
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -63,7 +63,7 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)
 

--- a/tests/test_cad_to_openmc/test_csg_cad_cladded_plate.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_cladded_plate.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import CladdedPlate
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -54,9 +54,9 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='cladded_plate.h5m',
@@ -72,10 +72,10 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0], csg_result_mat_3.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)

--- a/tests/test_cad_to_openmc/test_csg_cad_concentric_cylinders.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_concentric_cylinders.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ConcentricCylinders
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -54,9 +54,9 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='concentric_cylinders.h5m',
@@ -72,10 +72,10 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0], csg_result_mat_3.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)

--- a/tests/test_cad_to_openmc/test_csg_cad_cone.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_cone.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Cone
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -35,7 +35,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='cone.h5m',
@@ -51,6 +51,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_cross_junction.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_cross_junction.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import CrossJunction
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -45,8 +45,8 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='cross_junction.h5m',
@@ -62,8 +62,8 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_cubic_lattice.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_cubic_lattice.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import CubicLattice
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -45,8 +45,8 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='cubic_lattice.h5m',
@@ -62,8 +62,8 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_cuboid.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_cuboid.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Cuboid
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_comparing():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_comparing():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a Cuboid
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,7 +59,7 @@ def test_comparing():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)
 

--- a/tests/test_cad_to_openmc/test_csg_cad_cylinder.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_cylinder.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Cylinder
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a cylinder
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,7 +59,7 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)
 

--- a/tests/test_cad_to_openmc/test_csg_cad_cylinder_in_box.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_cylinder_in_box.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import CylinderInBox
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -45,8 +45,8 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='cylinder_in_box.h5m',
@@ -62,8 +62,8 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_cylindrical_intersection.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_cylindrical_intersection.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import CylindricalIntersection
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a CylindricalIntersection
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_divertor_monoblock.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_divertor_monoblock.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import DivertorMonoblock
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -45,8 +45,8 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='divertor_monoblock.h5m',
@@ -62,8 +62,8 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_eccentric_nested_cylinders.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_eccentric_nested_cylinders.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import EccentricNestedCylinders
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -45,8 +45,8 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='eccentric_nested_cylinders.h5m',
@@ -62,8 +62,8 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_ellipsoid.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_ellipsoid.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Ellipsoid
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_elliptic_cylinder.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_elliptic_cylinder.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo.elliptic_cylinder import EllipticCylinder
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_ellipticaltorus.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_ellipticaltorus.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Ellipticaltorus
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import numpy as np
 
 def test_compare():
@@ -47,7 +47,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a Ellipticaltorus
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -65,6 +65,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_fuel_pin_cell.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_fuel_pin_cell.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import FuelPinCell
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -54,9 +54,9 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='fuel_pin_cell.h5m',
@@ -72,10 +72,10 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0], csg_result_mat_3.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)

--- a/tests/test_cad_to_openmc/test_csg_cad_hemisphere.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_hemisphere.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Hemisphere
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_hexagonal_lattice_cell.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_hexagonal_lattice_cell.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import HexagonalLatticeCell
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -45,8 +45,8 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='hexagonal_lattice_cell.h5m',
@@ -62,8 +62,8 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_hexagonal_prism.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_hexagonal_prism.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import HexagonalPrism
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -35,7 +35,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='hexagonal_prism.h5m',
@@ -51,6 +51,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_hyperboloid.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_hyperboloid.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Hyperboloid
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_l_shaped.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_l_shaped.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import LShaped
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -35,7 +35,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='l_shaped.h5m',
@@ -51,6 +51,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_nestedcylinder.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_nestedcylinder.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import NestedCylinder
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -51,8 +51,8 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -70,8 +70,8 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_nestedsphere.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_nestedsphere.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import NestedSphere
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -51,8 +51,8 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -70,8 +70,8 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_nestedtorus.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_nestedtorus.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Nestedtorus
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 import numpy as np
 
 def test_compare():
@@ -59,7 +59,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="flux_tally")
+        csg_result = read_tally(sp_from_csg, "flux_tally")
 
     # making openmc.Model with cad_to_openmc geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -77,6 +77,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="flux_tally")
+        cad_result = read_tally(sp_from_cad, "flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0], rel_tol=0.05)
+    assert_tally_agreement(cad_result, csg_result, relative_tolerance=0.05)

--- a/tests/test_cad_to_openmc/test_csg_cad_ogive.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_ogive.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Ogive
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_oktavian.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_oktavian.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Oktavian
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -49,7 +49,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -67,6 +67,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(float(cad_result_mat_1.mean.flatten()[0]), float(csg_result_mat_1.mean.flatten()[0]), rel_tol=0.01)
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1, relative_tolerance=0.01)

--- a/tests/test_cad_to_openmc/test_csg_cad_overlapping_spheres.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_overlapping_spheres.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import OverlappingSpheres
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -45,8 +45,8 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='overlapping_spheres.h5m',
@@ -62,8 +62,8 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_paraboloid.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_paraboloid.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Paraboloid
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_pebble_bed_cell.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_pebble_bed_cell.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import PebbleBedCell
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -63,10 +63,10 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
-        csg_result_mat_4 = sp_from_csg.get_tally(name="mat4_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
+        csg_result_mat_4 = read_tally(sp_from_csg, "mat4_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='pebble_bed_cell.h5m',
@@ -82,12 +82,12 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
-        cad_result_mat_4 = sp_from_cad.get_tally(name="mat4_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
+        cad_result_mat_4 = read_tally(sp_from_cad, "mat4_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0], csg_result_mat_3.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_4.mean.flatten()[0], csg_result_mat_4.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)
+    assert_tally_agreement(cad_result_mat_4, csg_result_mat_4)

--- a/tests/test_cad_to_openmc/test_csg_cad_pipe.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_pipe.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Pipe
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_pipe_elbow.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_pipe_elbow.py
@@ -1,4 +1,5 @@
 from model_benchmark_zoo import PipeElbow
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import math
 
@@ -35,7 +36,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='pipe_elbow.h5m',
@@ -51,6 +52,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_pyramid.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_pyramid.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Pyramid
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -35,7 +35,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='pyramid.h5m',
@@ -51,6 +51,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_simple_tokamak.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_simple_tokamak.py
@@ -1,4 +1,5 @@
 from model_benchmark_zoo import SimpleTokamak
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import math
 
@@ -56,8 +57,8 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='simpletokamak.h5m',
@@ -72,8 +73,8 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_sphere.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_sphere.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Sphere
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,7 +59,7 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)
 

--- a/tests/test_cad_to_openmc/test_csg_cad_sphere_in_box.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_sphere_in_box.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import SphereInBox
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -45,8 +45,8 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='sphere_in_box.h5m',
@@ -62,8 +62,8 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_sphere_with_cylindrical_hole.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_sphere_with_cylindrical_hole.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import SphereWithCylindricalHole
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_sphere_with_multiple_holes.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_sphere_with_multiple_holes.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import SphereWithMultipleHoles
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -35,7 +35,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='sphere_with_multiple_holes.h5m',
@@ -51,6 +51,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_stepped_cylinder.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_stepped_cylinder.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import SteppedCylinder
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -35,11 +35,11 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='stepped_cylinder.h5m',
-        material_tags=['1'],
+        material_tags=['1', '1'],
     )
     dag_model = common_geometry_object.dagmc_model(
         h5m_filename='stepped_cylinder.h5m',
@@ -51,6 +51,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_t_junction.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_t_junction.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import TJunction
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -45,8 +45,8 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='t_junction.h5m',
@@ -62,8 +62,8 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)

--- a/tests/test_cad_to_openmc/test_csg_cad_tetrahedral.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_tetrahedral.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Tetrahedral
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -43,7 +43,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -61,7 +61,7 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)
 

--- a/tests/test_cad_to_openmc/test_csg_cad_thin_gap.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_thin_gap.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ThinGap
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # materials used in both simulations
@@ -49,8 +49,8 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a ThinGap
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -68,8 +68,8 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result2 = read_tally(sp_from_cad, "mat2_flux_tally")
 
-    assert math.isclose(cad_result1.mean.flatten()[0], csg_result1.mean.flatten()[0])
-    assert math.isclose(cad_result2.mean.flatten()[0], csg_result2.mean.flatten()[0])
+    assert_tally_agreement(cad_result1, csg_result1)
+    assert_tally_agreement(cad_result2, csg_result2)

--- a/tests/test_cad_to_openmc/test_csg_cad_thin_plate.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_thin_plate.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ThinPlate
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -35,7 +35,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='thin_plate.h5m',
@@ -51,6 +51,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_thin_walled_cylinder.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_thin_walled_cylinder.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ThinWalledCylinder
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -35,7 +35,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='thin_walled_cylinder.h5m',
@@ -51,6 +51,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_thin_walled_sphere.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_thin_walled_sphere.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ThinWalledSphere
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -35,7 +35,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='thin_walled_sphere.h5m',
@@ -51,6 +51,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_three_touching_cuboids.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_three_touching_cuboids.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import ThreeTouchingCuboids
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # materials used in both simulations
@@ -60,9 +60,9 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result_mat_1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result_mat_2 = sp_from_csg.get_tally(name="mat2_flux_tally")
-        csg_result_mat_3 = sp_from_csg.get_tally(name="mat3_flux_tally")
+        csg_result_mat_1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result_mat_2 = read_tally(sp_from_csg, "mat2_flux_tally")
+        csg_result_mat_3 = read_tally(sp_from_csg, "mat3_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -80,10 +80,10 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result_mat_1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result_mat_2 = sp_from_cad.get_tally(name="mat2_flux_tally")
-        cad_result_mat_3 = sp_from_cad.get_tally(name="mat3_flux_tally")
+        cad_result_mat_1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result_mat_2 = read_tally(sp_from_cad, "mat2_flux_tally")
+        cad_result_mat_3 = read_tally(sp_from_cad, "mat3_flux_tally")
 
-    assert math.isclose(cad_result_mat_1.mean.flatten()[0], csg_result_mat_1.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_2.mean.flatten()[0], csg_result_mat_2.mean.flatten()[0])
-    assert math.isclose(cad_result_mat_3.mean.flatten()[0], csg_result_mat_3.mean.flatten()[0])
+    assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
+    assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)

--- a/tests/test_cad_to_openmc/test_csg_cad_toroidal_sector.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_toroidal_sector.py
@@ -1,4 +1,5 @@
 from model_benchmark_zoo import ToroidalSector
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import math
 
@@ -35,7 +36,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='toroidal_sector.h5m',
@@ -51,6 +52,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_truncated_cone.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_truncated_cone.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import TruncatedCone
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # single material used in both simulations
@@ -41,7 +41,7 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -59,6 +59,6 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_two_tetrahedrons.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_two_tetrahedrons.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import TwoTetrahedrons
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare_csg_and_cad():
     # single material used in both simulations
@@ -47,7 +47,7 @@ def test_compare_csg_and_cad():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a sphere
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -65,6 +65,6 @@ def test_compare_csg_and_cad():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
     
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)

--- a/tests/test_cad_to_openmc/test_csg_cad_two_touching_cuboids.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_two_touching_cuboids.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import TwoTouchingCuboids
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     # materials used in both simulations
@@ -49,8 +49,8 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result1 = sp_from_csg.get_tally(name="mat1_flux_tally")
-        csg_result2 = sp_from_csg.get_tally(name="mat2_flux_tally")
+        csg_result1 = read_tally(sp_from_csg, "mat1_flux_tally")
+        csg_result2 = read_tally(sp_from_csg, "mat2_flux_tally")
 
     # making openmc.Model with DAGMC geometry and specifying mesh sizes to get a good representation of a TwoTouchingCuboids
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -68,8 +68,8 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result1 = sp_from_cad.get_tally(name="mat1_flux_tally")
-        cad_result2 = sp_from_cad.get_tally(name="mat2_flux_tally")
+        cad_result1 = read_tally(sp_from_cad, "mat1_flux_tally")
+        cad_result2 = read_tally(sp_from_cad, "mat2_flux_tally")
  
-    assert math.isclose(cad_result1.mean.flatten()[0], csg_result1.mean.flatten()[0])
-    assert math.isclose(cad_result2.mean.flatten()[0], csg_result2.mean.flatten()[0])
+    assert_tally_agreement(cad_result1, csg_result1)
+    assert_tally_agreement(cad_result2, csg_result2)

--- a/tests/test_cad_to_openmc/test_csg_cad_wedge.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_wedge.py
@@ -1,6 +1,6 @@
 from model_benchmark_zoo import Wedge
+from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
-import math
 
 def test_compare():
     mat1 = openmc.Material(name='1')
@@ -35,7 +35,7 @@ def test_compare():
     output_file_from_csg = csg_model.run()
 
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")
+        csg_result = read_tally(sp_from_csg, "mat1_flux_tally")
 
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
         h5m_filename='wedge.h5m',
@@ -51,6 +51,6 @@ def test_compare():
     output_file_from_cad = dag_model.run()
 
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = sp_from_cad.get_tally(name="mat1_flux_tally")
+        cad_result = read_tally(sp_from_cad, "mat1_flux_tally")
 
-    assert math.isclose(cad_result.mean.flatten()[0], csg_result.mean.flatten()[0])
+    assert_tally_agreement(cad_result, csg_result)


### PR DESCRIPTION
## The problem

The comparison tests could not fail.

Each test takes an `openmc.Tally` handle from the CSG statepoint inside a `with` block, but never reads its values there:

```python
with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
    csg_result = sp_from_csg.get_tally(name="mat1_flux_tally")   # lazy handle
```

OpenMC reads tally results lazily from the statepoint file, and both runs write `statepoint.10.h5` into the same working directory. By the time the assert runs, the DAGMC run has overwritten that file, so the CSG handle re-reads the DAGMC numbers:

```
cad_result.mean = 6.9361602933382684
csg_result.mean = 6.9361602933382684   <- true CSG value is 6.978693936525966
math.isclose    = True
```

`math.isclose` compares a value with itself, so the assert can never fail. All 110 tests in both suites share this pattern, so the suite has never compared CSG against CAD.

## The fix

New `model_benchmark_zoo.comparison` module:

- **`read_tally`** reads `mean` and `std_dev` eagerly while the statepoint is open, so the values cannot later be re-read from a file another run has replaced.
- **`assert_tally_agreement`** applies two checks, both of which must pass:
  - **relative**, 2% by default, bounding the systematic difference from faceting the CAD surfaces
  - **statistical**, 3 sigma by default, bounding consistency with the Monte Carlo uncertainties

All 110 tests rewritten to use them. The three pre-existing custom tolerances (oktavian 1%, nestedtorus 5%, simple_tokamak 1%) are preserved as `relative_tolerance=`.

## Two model bugs this exposed

| model | material | CSG volume | CAD volume | reported error |
|---|---|---|---|---|
| `blanket_module` | 1 | 12569.64 (wall) | 175.93 (channel) | 99.1% |
| `blanket_module` | 3 | 173.40 (channel) | 12576.00 (wall) | |
| `divertor_monoblock` | 1 | 4648.65 (block) | 414.69 (pipe wall) | 92.8% |
| `divertor_monoblock` | 2 | 413.82 (pipe wall) | 4642.83 (block) | |

`cad_to_dagmc` assigns `material_tags[i]` to the i-th solid of the assembly, so in both models the materials were swapped relative to `csg_model`. Fixed by adding the solids in the same order the CSG model lists its materials, matching the convention the rest of the zoo already follows. Both now agree with CSG under the gmsh mesher.

Also: `stepped_cylinder` no longer fuses its two cylinders with `combine()`. As separate solids it exercises imprinting of a contact patch strictly interior to the larger face, which is the case OCCT cannot imprint under full gluing. The README model count is corrected (it said 56 against 55 rows).

## CI is red, deliberately

The remaining failures are a `cad_to_dagmc` defect in the `tolerance` / `angular_tolerance` meshing path, not a problem with these models:

- On `two_touching_cuboids`, purely planar geometry, the gmsh `min_mesh_size` / `max_mesh_size` path reproduces CSG **exactly** (0.00% on both materials).
- The `tolerance` / `angular_tolerance` path gives the larger body correctly (0.30%) but the smaller body **15.47% low**.
- The DAGMC volumes are correct and identical between both paths (399.17 against an analytic 400.0), so the geometry measures right but transports wrong.
- Raising the particle count 40x does not shrink it: 15.42% at 2.6 sigma becomes 15.47% at 15.9 sigma.
- It reproduces on `t_junction` (15.85%) and on other models, always affecting the smaller of two touching bodies.

That points at the imprinted shared interface not actually being shared in that path. It needs its own issue against cad_to_dagmc. Leaving these failures visible rather than papering over them with `xfail`, since they are the point of the change.
