### PR TITLE
Add nestedtorus solids in the same order as its CSG materials

### DIFF
--- a/src/model_benchmark_zoo/nestedtorus.py
+++ b/src/model_benchmark_zoo/nestedtorus.py
@@ -56,16 +56,17 @@ class Nestedtorus(BaseCommonGeometryObject):
         """
         assembly = cq.Assembly(name="nestedtorus")
 
-        # Create the shells and the core
-        for i in range(len(self.minor_radii)):
-            if i == len(self.minor_radii) - 1:
-                # This is the core
-                core_torus = cq.Solid.makeTorus(self.major_radius, self.minor_radii[i])
-                assembly.add(core_torus, name=f"torus_core")
-            else:
-                outer_torus = cq.Solid.makeTorus(self.major_radius, self.minor_radii[i])
-                inner_torus = cq.Solid.makeTorus(self.major_radius, self.minor_radii[i+1])
-                shell = outer_torus.cut(inner_torus)
-                assembly.add(shell, name=f"torus_shell_{i}")
-        
+        # Solids are added in the same order as the materials in csg_model, as
+        # cad_to_dagmc assigns material_tags[i] to the i-th solid of the assembly.
+        # csg_model reverses its regions so they run from the inside out, so the
+        # core is added first and then each shell working outwards.
+        core_torus = cq.Solid.makeTorus(self.major_radius, self.minor_radii[-1])
+        assembly.add(core_torus, name=f"torus_core")
+
+        for i in range(len(self.minor_radii) - 2, -1, -1):
+            outer_torus = cq.Solid.makeTorus(self.major_radius, self.minor_radii[i])
+            inner_torus = cq.Solid.makeTorus(self.major_radius, self.minor_radii[i+1])
+            shell = outer_torus.cut(inner_torus)
+            assembly.add(shell, name=f"torus_shell_{i}")
+
         return assembly


### PR DESCRIPTION
`csg_model` builds its regions outermost first and then reverses them:

```python
# Reverse regions to have from inside to outside
regions.reverse()
```

so `materials[0]` is the core. `cadquery_assembly` added the outermost shell first and the core last, so the four materials ran in opposite orders in the two representations. `cad_to_dagmc` assigns `material_tags[i]` to the i-th solid of the assembly, so material 1 was the core in CSG and the outermost shell in CAD.

| material | CSG volume | CAD volume |
|---|---|---|
| mat1 | 197.7 | 1381.7 |
| mat2 | 597.4 | 987.0 |
| mat3 | 984.3 | 592.2 |
| mat4 | 1382.5 | 197.4 |

Fixed by building the core first and then each shell working outwards, matching the order `csg_model` uses. This is the convention the rest of the zoo follows. After the change:

| material | CSG volume | CAD volume |
|---|---|---|
| mat1 | 198.0 | 197.4 |
| mat2 | 595.1 | 592.2 |
| mat3 | 980.3 | 987.0 |
| mat4 | 1383.6 | 1381.7 |

CSG volumes are estimated by rejection sampling, hence the small spread.

## Why this one matters

It was the largest remaining disagreement in the suite, about 43%, and unlike most of the current failures it appeared in **both** the cad_to_dagmc and cad_to_openmc paths and under **both** meshing options. That combination is the signature of a model problem rather than a mesher one:

- `cad_to_openmc`: 42.886% relative, 22.9 sigma
- `cad_to_dagmc`: 43.16% on kwargs0 and 41.88% on kwargs1

Note the test carries `relative_tolerance=0.05`, a pre-existing 5% allowance, and it was still failing by a wide margin.

## How it was missed earlier

Same class of problem as the `blanket_module` and `divertor_monoblock` orderings fixed in #67. It escaped that sweep because the audit read `material_tags` out of the test files, and this test writes

```python
material_tags = ['1', '2', '3', '4']
```

with spaces around the `=`, which the pattern did not match, so the model was silently skipped rather than reported.

Re-running the corrected audit over every multi-solid model in the zoo finds no other genuine ordering mismatches. Three models are flagged by a naive one-material-per-solid check but are correct by design, as they deliberately share a tag across several solids: `cross_junction` (`['1', '2', '2']`), `cubic_lattice` (eight spheres sharing `'1'`) and `stepped_cylinder` (`['1', '1']`).
