### PR TITLE
Test the cad-to-dagmc-mesher backend alongside gmsh and cadquery

### DIFF
--- a/tests/test_cad_to_dagmc/test_csg_cad_annular_sector.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_annular_sector.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_annular_sector.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_annular_sector.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_blanket_module.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_blanket_module.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_blanket_module.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_blanket_module.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_box_with_spherical_cavity.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_box_with_spherical_cavity.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_box_with_spherical_cavity.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_box_with_spherical_cavity.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_capsule.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_capsule.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_capsule.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_capsule.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_chamfered_box.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_chamfered_box.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_chamfered_box.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_chamfered_box.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_circulartorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_circulartorus.py
@@ -8,7 +8,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_circulartorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_circulartorus.py
@@ -5,9 +5,11 @@ import numpy as np
 import pytest
 
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_cladded_plate.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cladded_plate.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_cladded_plate.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cladded_plate.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_concentric_cylinders.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_concentric_cylinders.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_concentric_cylinders.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_concentric_cylinders.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_cone.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cone.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_cone.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cone.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_cross_junction.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cross_junction.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_cross_junction.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cross_junction.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_cubic_lattice.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cubic_lattice.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_cubic_lattice.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cubic_lattice.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_cuboid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cuboid.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_cuboid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cuboid.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cylinder.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cylinder.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_cylinder_in_box.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cylinder_in_box.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_cylinder_in_box.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cylinder_in_box.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_cylindrical_intersection.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cylindrical_intersection.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_cylindrical_intersection.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cylindrical_intersection.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_divertor_monoblock.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_divertor_monoblock.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_divertor_monoblock.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_divertor_monoblock.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_eccentric_nested_cylinders.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_eccentric_nested_cylinders.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_eccentric_nested_cylinders.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_eccentric_nested_cylinders.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_ellipsoid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_ellipsoid.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_ellipsoid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_ellipsoid.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_elliptic_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_elliptic_cylinder.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_elliptic_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_elliptic_cylinder.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_ellipticaltorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_ellipticaltorus.py
@@ -4,9 +4,11 @@ import openmc
 import numpy as np
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_ellipticaltorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_ellipticaltorus.py
@@ -7,7 +7,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_fuel_pin_cell.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_fuel_pin_cell.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_fuel_pin_cell.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_fuel_pin_cell.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_hemisphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hemisphere.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_hemisphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hemisphere.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_lattice_cell.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_lattice_cell.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_lattice_cell.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_lattice_cell.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_prism.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_prism.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_prism.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hexagonal_prism.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_hyperboloid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hyperboloid.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_hyperboloid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_hyperboloid.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_l_shaped.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_l_shaped.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_l_shaped.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_l_shaped.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedcylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedcylinder.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedcylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedcylinder.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedsphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedsphere.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedsphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedsphere.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedtorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedtorus.py
@@ -4,9 +4,11 @@ import openmc
 import numpy as np
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedtorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedtorus.py
@@ -7,7 +7,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_ogive.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_ogive.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_ogive.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_ogive.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_oktavian.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_oktavian.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_oktavian.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_oktavian.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_overlapping_spheres.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_overlapping_spheres.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.001,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.001,
         'max_mesh_size': 0.1},
-        {'tolerance': 0.01,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.01,
         'angular_tolerance': 0.01,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_overlapping_spheres.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_overlapping_spheres.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.001,
         'max_mesh_size': 0.1},
         {'tolerance': 0.01,
-        'angular_tolerance': 0.01,},]
+        'angular_tolerance': 0.01,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_paraboloid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_paraboloid.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_paraboloid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_paraboloid.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_pebble_bed_cell.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pebble_bed_cell.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_pebble_bed_cell.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pebble_bed_cell.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_pipe.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pipe.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_pipe.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pipe.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_pipe_elbow.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pipe_elbow.py
@@ -7,7 +7,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_pipe_elbow.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pipe_elbow.py
@@ -4,9 +4,11 @@ import openmc
 import math
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_pyramid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pyramid.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_pyramid.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_pyramid.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_simple_tokamak.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_simple_tokamak.py
@@ -7,7 +7,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.05,
         'max_mesh_size': 5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_simple_tokamak.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_simple_tokamak.py
@@ -4,9 +4,11 @@ import openmc
 import math
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.05,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.05,
         'max_mesh_size': 5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere_in_box.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere_in_box.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere_in_box.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere_in_box.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_cylindrical_hole.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_cylindrical_hole.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_cylindrical_hole.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_cylindrical_hole.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_multiple_holes.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_multiple_holes.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_multiple_holes.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_sphere_with_multiple_holes.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_stepped_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_stepped_cylinder.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_stepped_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_stepped_cylinder.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_t_junction.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_t_junction.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_t_junction.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_t_junction.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_tetrahedral.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_tetrahedral.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_tetrahedral.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_tetrahedral.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_gap.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_gap.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_gap.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_gap.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_plate.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_plate.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_plate.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_plate.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_cylinder.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_cylinder.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_sphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_sphere.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_sphere.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_thin_walled_sphere.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_three_touching_cuboids.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_three_touching_cuboids.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_three_touching_cuboids.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_three_touching_cuboids.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_toroidal_sector.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_toroidal_sector.py
@@ -7,7 +7,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_toroidal_sector.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_toroidal_sector.py
@@ -4,9 +4,11 @@ import openmc
 import math
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_truncated_cone.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_truncated_cone.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_truncated_cone.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_truncated_cone.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_annular_sectors.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_annular_sectors.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_annular_sectors.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_annular_sectors.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_annular_sectors_partial_arc.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_annular_sectors_partial_arc.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_annular_sectors_partial_arc.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_annular_sectors_partial_arc.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_tetrahedrons.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_tetrahedrons.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_tetrahedrons.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_tetrahedrons.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_touching_cuboids.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_touching_cuboids.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_two_touching_cuboids.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_two_touching_cuboids.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):

--- a/tests/test_cad_to_dagmc/test_csg_cad_wedge.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_wedge.py
@@ -3,9 +3,11 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
-kwargs_options = [{'min_mesh_size': 0.01,
+kwargs_options = [{'meshing_backend': 'gmsh',
+        'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
-        {'tolerance': 0.1,
+        {'meshing_backend': 'cadquery',
+        'tolerance': 0.1,
         'angular_tolerance': 0.1,},
         {'meshing_backend': 'cad-to-dagmc-mesher',
         'tolerance': 0.01,

--- a/tests/test_cad_to_dagmc/test_csg_cad_wedge.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_wedge.py
@@ -6,7 +6,10 @@ import pytest
 kwargs_options = [{'min_mesh_size': 0.01,
         'max_mesh_size': 0.5},
         {'tolerance': 0.1,
-        'angular_tolerance': 0.1,},]
+        'angular_tolerance': 0.1,},
+        {'meshing_backend': 'cad-to-dagmc-mesher',
+        'tolerance': 0.01,
+        'angular_tolerance': 0.2,},]
 
 @pytest.mark.parametrize('kwargs', kwargs_options)
 def test_compare(kwargs):


### PR DESCRIPTION
`cad_to_dagmc` can mesh with three backends but the zoo only exercised two, gmsh via `min_mesh_size`/`max_mesh_size` and cadquery via `tolerance`/`angular_tolerance`. This adds the third as another `kwargs_options` entry so every model is checked against it:

```python
kwargs_options = [{'min_mesh_size': 0.01,
        'max_mesh_size': 0.5},
        {'tolerance': 0.1,
        'angular_tolerance': 0.1,},
        {'meshing_backend': 'cad-to-dagmc-mesher',
        'tolerance': 0.01,
        'angular_tolerance': 0.2,},]
```

The backend has to be named explicitly, because `tolerance` and `angular_tolerance` are shared with the cadquery backend and cannot select it on their own.

**No CI changes needed.** `cad_to_dagmc` requires `cad-to-dagmc-mesher>=0.1.7`, so the existing unpinned `pip install cad_to_dagmc` already pulls it, and the package ships an abi3 manylinux wheel covering the Python version CI uses.

## Viability check

Before wiring it into 57 test files, every model was exported through the new backend. All 57 export successfully, each with the expected number of volumes and with the shared surface between touching solids present.

## Results

Full suite with all three backends: **158 passed, 13 failed**. The new backend contributes 4 failures, and they are the same four models that already fail on the cadquery backend, so it adds no failure of its own.

| backend | failures | models |
|---|---|---|
| gmsh | 5 | circulartorus, cylinder, ellipticaltorus, nestedtorus, simple_tokamak |
| cadquery | 4 | blanket_module, circulartorus, ellipticaltorus, nestedtorus |
| cad-to-dagmc-mesher | 4 | blanket_module, circulartorus, ellipticaltorus, nestedtorus |

Causes of the pre-existing failures, none specific to this backend:

- **circulartorus 5.2%** and **ellipticaltorus 7.2%** fail on all three backends by nearly the same margin, which points at the fidelity of triangulating double curvature rather than at any one backend.
- **nestedtorus about 43%** on all three. Its tally is unfiltered, so it scores track length in the void that `bounded_universe()` leaves around the CAD geometry, which the CSG model does not have. Being addressed separately.
- The rest are marginal, between 1.3% and 2.8%.

## Note on the environment used

These numbers were produced with the `cadquery_direct_mesh_plugin` fix from jmwright/cadquery-direct-mesh-plugin#10 installed. Without it the cadquery backend fails far more widely, which is the currently red CI on main. The mesher backend is unaffected by that issue either way, as it does not go through `to_mesh`, so its 4 failures stand regardless.
