### PR TITLE
Filter the nestedtorus tallies by material

### DIFF
--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedtorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedtorus.py
@@ -37,10 +37,17 @@ def test_compare(kwargs):
     common_geometry_object = Nestedtorus(major_radius=major_radius, minor_radii=minor_radii)
     common_geometry_object.export_stp_file("nestedtorus.stp")
 
-    # tallies used in both simulations
-    tally = openmc.Tally(name='flux_tally')
-    tally.scores = ['flux']
-    my_tallies = openmc.Tallies([tally])
+    # tallies used in both simulations, one per material. Filtering by material
+    # keeps the comparison to the geometry itself. An unfiltered tally also scores
+    # the void that bounded_universe leaves around the CAD geometry, which the CSG
+    # model does not have, so the two sides would not be measuring the same thing.
+    tallies = []
+    for i, material in enumerate(materials):
+        tally = openmc.Tally(name=f'mat{i + 1}_flux_tally')
+        tally.filters = [openmc.MaterialFilter(material)]
+        tally.scores = ['flux']
+        tallies.append(tally)
+    my_tallies = openmc.Tallies(tallies)
 
     my_settings = openmc.Settings()
     my_settings.batches = 10
@@ -66,7 +73,10 @@ def test_compare(kwargs):
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = read_tally(sp_from_csg, "flux_tally")
+        csg_results = [
+            read_tally(sp_from_csg, f"mat{i + 1}_flux_tally")
+            for i in range(len(materials))
+        ]
 
     # making openmc.Model with DAGMC geometry
     common_geometry_object.export_h5m_file_with_cad_to_dagmc(
@@ -85,6 +95,10 @@ def test_compare(kwargs):
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = read_tally(sp_from_cad, "flux_tally")
+        cad_results = [
+            read_tally(sp_from_cad, f"mat{i + 1}_flux_tally")
+            for i in range(len(materials))
+        ]
     
-    assert_tally_agreement(cad_result, csg_result, relative_tolerance=0.05)
+    for cad_result, csg_result in zip(cad_results, csg_results):
+        assert_tally_agreement(cad_result, csg_result, relative_tolerance=0.05)

--- a/tests/test_cad_to_openmc/test_csg_cad_nestedtorus.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_nestedtorus.py
@@ -30,10 +30,17 @@ def test_compare():
     common_geometry_object = Nestedtorus(major_radius=major_radius, minor_radii=minor_radii)
     common_geometry_object.export_stp_file("nestedtorus.stp")
 
-    # tallies used in both simulations
-    tally = openmc.Tally(name='flux_tally')
-    tally.scores = ['flux']
-    my_tallies = openmc.Tallies([tally])
+    # tallies used in both simulations, one per material. Filtering by material
+    # keeps the comparison to the geometry itself. An unfiltered tally also scores
+    # the void that bounded_universe leaves around the CAD geometry, which the CSG
+    # model does not have, so the two sides would not be measuring the same thing.
+    tallies = []
+    for i, material in enumerate(materials):
+        tally = openmc.Tally(name=f'mat{i + 1}_flux_tally')
+        tally.filters = [openmc.MaterialFilter(material)]
+        tally.scores = ['flux']
+        tallies.append(tally)
+    my_tallies = openmc.Tallies(tallies)
 
     my_settings = openmc.Settings()
     my_settings.batches = 10
@@ -59,7 +66,10 @@ def test_compare():
 
     # extracting the tally result from the CSG simulation
     with openmc.StatePoint(output_file_from_csg) as sp_from_csg:
-        csg_result = read_tally(sp_from_csg, "flux_tally")
+        csg_results = [
+            read_tally(sp_from_csg, f"mat{i + 1}_flux_tally")
+            for i in range(len(materials))
+        ]
 
     # making openmc.Model with cad_to_openmc geometry
     common_geometry_object.export_h5m_file_with_cad_to_openmc(
@@ -77,6 +87,10 @@ def test_compare():
 
     # extracting the tally result from the DAGMC simulation
     with openmc.StatePoint(output_file_from_cad) as sp_from_cad:
-        cad_result = read_tally(sp_from_cad, "flux_tally")
+        cad_results = [
+            read_tally(sp_from_cad, f"mat{i + 1}_flux_tally")
+            for i in range(len(materials))
+        ]
     
-    assert_tally_agreement(cad_result, csg_result, relative_tolerance=0.05)
+    for cad_result, csg_result in zip(cad_results, csg_results):
+        assert_tally_agreement(cad_result, csg_result, relative_tolerance=0.05)


### PR DESCRIPTION
`nestedtorus` was the only test in either suite with an unfiltered tally:

```python
tally = openmc.Tally(name='flux_tally')
tally.scores = ['flux']
```

With no filter it scores track length everywhere, including the void that `bounded_universe()` leaves between the CAD geometry and its bounding box. The CSG model puts `boundary_type="vacuum"` on the outermost torus surface and has no such void, so particles are killed on the way out. The two sides were therefore measuring different regions:

```
CSG, vacuum on the torus surface   6.12332
DAGMC via bounded_universe         8.78918   (+43.5%)
```

That is why the model failed by the same ~43% on all three meshing backends: it is a property of the comparison, not of the geometry or of any backend.

## Change

Score one tally per material, as every other test in the suite does, so the comparison covers the geometry rather than its surroundings. As a side benefit the test now becomes sensitive to which material ends up in which volume, something the unfiltered tally could never detect, which is what let the ordering problem fixed in #69 go unnoticed.

## Result

The disagreement drops from about **43%** to about **6.7%**.

The residual is left failing rather than papered over. It sits in the same range as the other two torus models, `circulartorus` at 5.2% and `ellipticaltorus` at 7.2%, all three of which fail on every backend by a similar margin. That consistent signature across unrelated backends points at the fidelity of triangulating double curvature. The existing `relative_tolerance=0.05` on this test is therefore left as it is rather than widened to make it pass, since doing so would hide the very effect the zoo exists to measure.

Applied to both the cad_to_dagmc and cad_to_openmc suites.
