### PR TITLE
Converge the blanket module and simple tokamak tally comparisons

### DIFF
--- a/examples/compare_csg_cad_blanket_module.py
+++ b/examples/compare_csg_cad_blanket_module.py
@@ -41,7 +41,11 @@ my_tallies = openmc.Tallies([tally1, tally2, tally3])
 my_settings = openmc.Settings()
 my_settings.batches = 10
 my_settings.inactive = 0
-my_settings.particles = 500
+# The mat3 coolant channel is only 176 cm3 of the 24000 cm3 module and sits away
+# from the source, so it collects far fewer tracks than the wall and the breeder.
+# Its flux tally needs many more particles than the other two before the CSG and
+# CAD results can be meaningfully compared.
+my_settings.particles = 100000
 my_settings.run_mode = 'fixed source'
 
 # Source inside the structural wall (top wall region)

--- a/tests/test_cad_to_dagmc/test_csg_cad_blanket_module.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_blanket_module.py
@@ -50,7 +50,14 @@ def test_compare(kwargs):
     my_settings = openmc.Settings()
     my_settings.batches = 10
     my_settings.inactive = 0
-    my_settings.particles = 500
+    # The mat3 coolant channel is only 176 cm3 of the 24000 cm3 module and sits
+    # away from the source, so it collects far fewer tracks than the wall and the
+    # breeder. At 500 particles its flux tally carries around 16% statistical
+    # uncertainty, so comparing it against a 2% relative tolerance tests the random
+    # number stream rather than the geometry and fails around 20% of the time. The
+    # CSG and CAD geometries agree to better than 0.05% in volume, so the particle
+    # count is raised until the comparison is dominated by the geometry instead.
+    my_settings.particles = 100000
     my_settings.run_mode = 'fixed source'
 
     my_source = openmc.IndependentSource()
@@ -91,4 +98,8 @@ def test_compare(kwargs):
 
     assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
     assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
-    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)
+    # Even at this particle count the small channel keeps around 1% statistical
+    # scatter, an order of magnitude more than the wall and breeder tallies, so it
+    # is compared against a tolerance matched to what it can actually resolve. The
+    # strict default tolerance still applies to the two large tallies above.
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3, relative_tolerance=0.05)

--- a/tests/test_cad_to_dagmc/test_csg_cad_simple_tokamak.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_simple_tokamak.py
@@ -47,7 +47,12 @@ def test_compare(kwargs):
     my_settings = openmc.Settings()
     my_settings.batches = 10
     my_settings.inactive = 0
-    my_settings.particles = 500
+    # The mat2 blanket tally carries around 7.5% statistical uncertainty at 500
+    # particles, so comparing it against the 1% relative tolerance below tests the
+    # random number stream rather than the geometry. At this particle count that
+    # uncertainty drops to around 1% and all three meshing backends agree with the
+    # CSG result to better than 0.15%.
+    my_settings.particles = 50000
     my_settings.run_mode = 'fixed source'
 
     # Create a DT ring source

--- a/tests/test_cad_to_openmc/test_csg_cad_blanket_module.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_blanket_module.py
@@ -38,7 +38,14 @@ def test_compare():
     my_settings = openmc.Settings()
     my_settings.batches = 10
     my_settings.inactive = 0
-    my_settings.particles = 500
+    # The mat3 coolant channel is only 176 cm3 of the 24000 cm3 module and sits
+    # away from the source, so it collects far fewer tracks than the wall and the
+    # breeder. At 500 particles its flux tally carries around 16% statistical
+    # uncertainty, so comparing it against a 2% relative tolerance tests the random
+    # number stream rather than the geometry and fails around 20% of the time. The
+    # CSG and CAD geometries agree to better than 0.05% in volume, so the particle
+    # count is raised until the comparison is dominated by the geometry instead.
+    my_settings.particles = 100000
     my_settings.run_mode = 'fixed source'
 
     my_source = openmc.IndependentSource()
@@ -78,4 +85,8 @@ def test_compare():
 
     assert_tally_agreement(cad_result_mat_1, csg_result_mat_1)
     assert_tally_agreement(cad_result_mat_2, csg_result_mat_2)
-    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3)
+    # Even at this particle count the small channel keeps around 1% statistical
+    # scatter, an order of magnitude more than the wall and breeder tallies, so it
+    # is compared against a tolerance matched to what it can actually resolve. The
+    # strict default tolerance still applies to the two large tallies above.
+    assert_tally_agreement(cad_result_mat_3, csg_result_mat_3, relative_tolerance=0.05)

--- a/tests/test_cad_to_openmc/test_csg_cad_simple_tokamak.py
+++ b/tests/test_cad_to_openmc/test_csg_cad_simple_tokamak.py
@@ -35,7 +35,11 @@ def test_compare():
     my_settings = openmc.Settings()
     my_settings.batches = 10
     my_settings.inactive = 0
-    my_settings.particles = 500
+    # The mat2 blanket tally carries around 7.5% statistical uncertainty at 500
+    # particles, so comparing it against the relative tolerance tests the random
+    # number stream rather than the geometry. At this particle count that
+    # uncertainty drops to around 1%.
+    my_settings.particles = 50000
     my_settings.run_mode = 'fixed source'
 
     # Create a DT ring source


### PR DESCRIPTION
## Problem

Both of these tests compared a tally whose statistical uncertainty was much larger than the relative tolerance it was checked against, so the assertion was testing the random number stream rather than the geometry.

**Blanket module.** The mat3 coolant channel is 176 cm3 of the 24000 cm3 module and is shielded from the source, so at 500 particles its flux tally carried around 16% statistical uncertainty while being compared against a 2% relative tolerance. Across 20 random seeds that combination failed 20% of the time from identical geometry. Raising the mesh resolution did not help, because the mesh was never the problem: sweeping gmsh `max_mesh_size` from 0.5 down to 0.05 leaves the mat3 difference flat at around 0.4%, under 0.5 sigma.

The geometry itself is correct. Stochastic volumes of the CSG cells match the CadQuery solids to better than 0.05%:

| | CSG cell | CAD solid | analytic |
|---|---|---|---|
| mat1 wall | 12576.00 | 12576.0000 | 12576 |
| mat2 breeder | 11247.99 | 11248.0708 | 11248.07 |
| mat3 channel | 176.01 | 175.9292 | 175.93 |

The CAD bounding boxes also match the CSG surfaces exactly, and the solid order matches the material order.

**Simple tokamak.** The mat2 blanket tally carried around 7.5% statistical uncertainty at 500 particles against a 1% relative tolerance.

## Change

Raise the particle counts so both comparisons are dominated by the geometry rather than by counting statistics.

The blanket module channel still keeps around 1% scatter at the higher count, an order of magnitude more than the wall and breeder tallies, so it is compared against a tolerance matched to what it can actually resolve. The two large tallies keep the strict default tolerance. This follows the existing per-test tolerance pattern in `test_csg_cad_oktavian.py` and `test_csg_cad_simple_tokamak.py`.

The tokamak wall time is dominated by meshing rather than transport, so the higher count costs very little there: the model takes about the same wall time at 500 and at 20000 particles.

## Validation

- Blanket module: 20 seeds x 3 meshing backends, 0 failures out of 60. mat3 scatter sd 1.08%, worst absolute difference 2.40% against the 5% limit.
- Simple tokamak: all three meshing backends agree with the CSG result to better than 0.15% against the 1% limit, with mat2 uncertainty down from 7.5% to about 1%.
- Full `tests/test_cad_to_dagmc` suite before this change: 13 failed, 158 passed. After: 10 failed, 161 passed. The three fixed cases are exactly the blanket module cadquery and cad-to-dagmc-mesher backends and the tokamak gmsh backend, with no other verdict changed.

`comparison.py` is deliberately untouched, so no other model's result moves.

## Not addressed here

The 10 remaining failures are real geometry differences rather than noise, and are being investigated separately:

- `circulartorus`, `ellipticaltorus`, `nestedtorus`: differences of 5% to 12% that grow in significance as the runs converge, up to 40 to 53 sigma.
- `cylinder` on the gmsh backend only: a stable -1.98% difference at every particle count, while the cadquery and cad-to-dagmc-mesher backends agree to within 0.08%. More particles make this one worse, not better.

The `tests/test_cad_to_openmc` copies of both tests get the same particle counts, but that suite could not be run locally because `CAD_to_OpenMC` is not installed in this environment.