### PR TITLE
Let particles re-enter the CSG tori and resolve radius 1 curved surfaces

### DIFF
--- a/src/model_benchmark_zoo/circulartorus.py
+++ b/src/model_benchmark_zoo/circulartorus.py
@@ -11,12 +11,22 @@ class Circulartorus(BaseCommonGeometryObject):
             a=self.major_radius,
             b=self.minor_radius,
             c=self.minor_radius,
+        )
+        # A torus is not convex, so a particle leaving the inner surface can cross
+        # the hole and re-enter on the far side of the ring. Putting the vacuum
+        # boundary on the torus surface itself would kill those particles, while
+        # the CAD model transports them because dagmc_model wraps the geometry
+        # with bounded_universe, which leaves a void region around it. Enclose the
+        # torus in a void so both models describe the same transport problem.
+        boundary = openmc.Sphere(
+            r=2 * (self.major_radius + self.minor_radius),
             boundary_type="vacuum"
         )
         region = -surface
         cell = openmc.Cell(region=region)
         cell.fill = materials[0]
-        geometry = openmc.Geometry([cell])
+        surrounding_void = openmc.Cell(region=+surface & -boundary)
+        geometry = openmc.Geometry([cell, surrounding_void])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/ellipticaltorus.py
+++ b/src/model_benchmark_zoo/ellipticaltorus.py
@@ -11,12 +11,23 @@ class Ellipticaltorus(BaseCommonGeometryObject):
     def csg_model(self, materials):
         import openmc
 
-        surface = openmc.ZTorus(a=self.major_radius, b=self.minor_radius1, c=self.minor_radius2, boundary_type="vacuum")
+        surface = openmc.ZTorus(a=self.major_radius, b=self.minor_radius1, c=self.minor_radius2)
+        # A torus is not convex, so a particle leaving the inner surface can cross
+        # the hole and re-enter on the far side of the ring. Putting the vacuum
+        # boundary on the torus surface itself would kill those particles, while
+        # the CAD model transports them because dagmc_model wraps the geometry
+        # with bounded_universe, which leaves a void region around it. Enclose the
+        # torus in a void so both models describe the same transport problem.
+        boundary = openmc.Sphere(
+            r=2 * (self.major_radius + max(self.minor_radius1, self.minor_radius2)),
+            boundary_type="vacuum"
+        )
         region = -surface
         cell = openmc.Cell(region=region)
         cell.fill = materials[0]
+        surrounding_void = openmc.Cell(region=+surface & -boundary)
         my_materials = openmc.Materials(materials)
-        geometry = openmc.Geometry([cell])
+        geometry = openmc.Geometry([cell, surrounding_void])
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model
 

--- a/src/model_benchmark_zoo/nestedtorus.py
+++ b/src/model_benchmark_zoo/nestedtorus.py
@@ -23,9 +23,19 @@ class Nestedtorus(BaseCommonGeometryObject):
             raise ValueError(f"Number of materials ({len(materials)}) must be at least equal to the number of minor radii ({len(self.minor_radii)}).")
 
         surfaces = [openmc.ZTorus(a=self.major_radius, b=r, c=r) for r in self.minor_radii]
-        
-        # Add vacuum boundary to the outermost surface
-        surfaces[0].boundary_type = "vacuum"
+
+        # A torus is not convex, so a particle leaving the inner surface can cross
+        # the hole and re-enter on the far side of the ring. Putting the vacuum
+        # boundary on the outermost torus surface itself would kill those
+        # particles, while the CAD model transports them because dagmc_model wraps
+        # the geometry with bounded_universe, which leaves a void region around it.
+        # Enclose the tori in a void so both models describe the same transport
+        # problem. Re-entering particles cross the outer shells first, so those are
+        # the ones most affected.
+        boundary = openmc.Sphere(
+            r=2 * (self.major_radius + self.minor_radii[0]),
+            boundary_type="vacuum"
+        )
 
         regions = []
         # Create the shells
@@ -44,7 +54,9 @@ class Nestedtorus(BaseCommonGeometryObject):
             cell = openmc.Cell(region=region)
             cell.fill = materials[i]
             cells.append(cell)
-        
+
+        cells.append(openmc.Cell(region=+surfaces[0] & -boundary))
+
         geometry = openmc.Geometry(cells)
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)

--- a/tests/test_cad_to_dagmc/test_csg_cad_cylinder.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_cylinder.py
@@ -3,9 +3,14 @@ from model_benchmark_zoo.comparison import assert_tally_agreement, read_tally
 import openmc
 import pytest
 
+# The cylinder has a radius of 1, so a max_mesh_size of 0.5 leaves only about a
+# dozen facets around the circumference and the faceted volume falls around 2%
+# short of the analytic cylinder. Refining to 0.1 brings the CAD result to within
+# 0.1% of the CSG result. The other two backends already resolve this radius at
+# their settings below.
 kwargs_options = [{'meshing_backend': 'gmsh',
         'min_mesh_size': 0.01,
-        'max_mesh_size': 0.5},
+        'max_mesh_size': 0.1},
         {'meshing_backend': 'cadquery',
         'tolerance': 0.1,
         'angular_tolerance': 0.1,},

--- a/tests/test_cad_to_dagmc/test_csg_cad_nestedtorus.py
+++ b/tests/test_cad_to_dagmc/test_csg_cad_nestedtorus.py
@@ -4,9 +4,12 @@ import openmc
 import numpy as np
 import pytest
 
+# The innermost torus has a minor radius of 1, so a max_mesh_size of 0.5 leaves
+# its surface too coarsely faceted and the core tally falls over 1% short.
+# Refining to 0.1 brings all four tallies to within 0.1% of the CSG result.
 kwargs_options = [{'meshing_backend': 'gmsh',
         'min_mesh_size': 0.01,
-        'max_mesh_size': 0.5},
+        'max_mesh_size': 0.1},
         {'meshing_backend': 'cadquery',
         'tolerance': 0.1,
         'angular_tolerance': 0.1,},


### PR DESCRIPTION
Fixes #73.

Two independent causes made the `circulartorus`, `ellipticaltorus`, `nestedtorus` and `cylinder` comparisons fail. Both are real geometry differences rather than Monte Carlo noise: their significance grew as the runs converged, reaching 40 to 72 combined sigma at 1e6 particles.

## The CSG tori killed particles that should re-enter through the hole

The three torus `csg_model` methods set `boundary_type="vacuum"` on the outermost `openmc.ZTorus` surface itself. A torus is not convex, so a particle leaving the inner surface can cross the hole and re-enter on the far side of the ring. The vacuum boundary killed those particles.

The CAD side transports them correctly, because `dagmc_model` wraps the geometry with `bounded_universe()` (`src/model_benchmark_zoo/utils.py:49`), which leaves a void region between the model and the vacuum boundary. The two sides were therefore not describing the same transport problem, and the CAD result was higher because it collected the extra track length.

DAGMC is the correct side here: for a torus sitting in vacuum, re-entry is real physics. This was a modelling bug in the CSG models, not a tolerance or faceting matter.

Enclosing each torus in a void out to a bounding sphere, which is what `bounded_universe()` gives the CAD side, removes the discrepancy. Flux tally, gmsh backend, 1e6 particles:

| model | before | after |
|---|---|---|
| circular torus | +5.70% (66.7 sigma) | -0.09% (1.2 sigma) |
| elliptical torus | +7.20% (72.1 sigma) | -0.17% (1.9 sigma) |
| nested torus, mat2 shell | +4.66% (38.4 sigma) | +0.03% |
| nested torus, mat3 shell | +7.33% (48.6 sigma) | +0.01% |
| nested torus, mat4 outer shell | +11.56% (71.9 sigma) | +0.00% |

The graded pattern across the nested torus shells was the signature of this effect. Re-entering particles cross the outer shells first, so the outermost shell gained the most (+11.56%) while the core, which they rarely reach, was unaffected (-0.05%).

The bounding sphere radius does not affect the result, since the surrounding region is void and particles travel in straight lines through it. It only has to contain the torus.

## gmsh at max_mesh_size 0.5 under-resolves curved surfaces of radius 1

This is what the `cylinder` failure was, and it is what remained in the nested torus core once the re-entry problem was fixed.

`Cylinder(radius=1, height=100)` meshed at 0.5 has only about a dozen facets around the circumference, a roughly 2% volume deficit that shows up directly in the flux. Refining converges it cleanly:

| gmsh max_mesh_size | cylinder CAD vs CSG |
|---|---|
| 0.5 | -1.98% (10.7 sigma) |
| 0.25 | -0.37% (2.0 sigma) |
| 0.1 | -0.06% (0.3 sigma) |
| 0.05 | -0.01% (0.1 sigma) |

The `cadquery` and `cad-to-dagmc-mesher` backends already resolved this radius at their existing settings, which is why only the gmsh parameter changes. The nested torus gets the same change for its innermost torus, which also has a minor radius of 1.

Worth noting that the cylinder failure reported 2.001% against a 2.000% limit and looked like noise in a single run. It was not: the difference was stable at every particle count and only its significance changed.

## Verification

The full `tests/test_cad_to_dagmc` suite now passes, **171 of 171**, up from 161 passed and 10 failed on current main.

Suite wall time goes from about 8.5 to about 12.5 minutes locally, almost all of it the finer nested torus mesh (that one test takes 208s). Happy to relax it to 0.2 if that is too slow for CI, at the cost of some accuracy on the core tally.

The `tests/test_cad_to_openmc` copies are unaffected by the mesh change since they use their own backend, and they pick up the torus model fix automatically, but that suite could not be run locally because `CAD_to_OpenMC` is not installed in this environment.