### PR TITLE
Enclose every CSG and CAD model in the same padded bounding box

### DIFF
--- a/src/model_benchmark_zoo/annular_sector.py
+++ b/src/model_benchmark_zoo/annular_sector.py
@@ -9,7 +9,7 @@ class AnnularSector(BaseCommonGeometryObject):
         self.height = height
         self.angle = angle
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         ri = self.inner_radius

--- a/src/model_benchmark_zoo/blanket_module.py
+++ b/src/model_benchmark_zoo/blanket_module.py
@@ -8,7 +8,7 @@ class BlanketModule(BaseCommonGeometryObject):
         self.wall_thickness = wall_thickness
         self.channel_radius = channel_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         ow = self.outer_width

--- a/src/model_benchmark_zoo/box_with_spherical_cavity.py
+++ b/src/model_benchmark_zoo/box_with_spherical_cavity.py
@@ -9,7 +9,7 @@ class BoxWithSphericalCavity(BaseCommonGeometryObject):
         self.width = width
         self.sphere_radius = sphere_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         box_surface = openmc.model.RectangularParallelepiped(

--- a/src/model_benchmark_zoo/capsule.py
+++ b/src/model_benchmark_zoo/capsule.py
@@ -5,7 +5,7 @@ class Capsule(BaseCommonGeometryObject):
         self.radius = radius
         self.cylinder_height = cylinder_height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         r = self.radius

--- a/src/model_benchmark_zoo/chamfered_box.py
+++ b/src/model_benchmark_zoo/chamfered_box.py
@@ -7,7 +7,7 @@ class ChamferedBox(BaseCommonGeometryObject):
         self.width = width
         self.chamfer = chamfer
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         w = self.width

--- a/src/model_benchmark_zoo/circulartorus.py
+++ b/src/model_benchmark_zoo/circulartorus.py
@@ -4,7 +4,7 @@ class Circulartorus(BaseCommonGeometryObject):
         self.major_radius = major_radius
         self.minor_radius = minor_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         surface = openmc.ZTorus(
@@ -12,21 +12,10 @@ class Circulartorus(BaseCommonGeometryObject):
             b=self.minor_radius,
             c=self.minor_radius,
         )
-        # A torus is not convex, so a particle leaving the inner surface can cross
-        # the hole and re-enter on the far side of the ring. Putting the vacuum
-        # boundary on the torus surface itself would kill those particles, while
-        # the CAD model transports them because dagmc_model wraps the geometry
-        # with bounded_universe, which leaves a void region around it. Enclose the
-        # torus in a void so both models describe the same transport problem.
-        boundary = openmc.Sphere(
-            r=2 * (self.major_radius + self.minor_radius),
-            boundary_type="vacuum"
-        )
         region = -surface
         cell = openmc.Cell(region=region)
         cell.fill = materials[0]
-        surrounding_void = openmc.Cell(region=+surface & -boundary)
-        geometry = openmc.Geometry([cell, surrounding_void])
+        geometry = openmc.Geometry([cell])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/cladded_plate.py
+++ b/src/model_benchmark_zoo/cladded_plate.py
@@ -7,7 +7,7 @@ class CladdedPlate(BaseCommonGeometryObject):
         self.core_thickness = core_thickness
         self.clad_thickness = clad_thickness
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         w = self.width

--- a/src/model_benchmark_zoo/concentric_cylinders.py
+++ b/src/model_benchmark_zoo/concentric_cylinders.py
@@ -11,7 +11,7 @@ class ConcentricCylinders(BaseCommonGeometryObject):
         self.height = height
         self.radii = radii
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         h = self.height

--- a/src/model_benchmark_zoo/cone.py
+++ b/src/model_benchmark_zoo/cone.py
@@ -7,7 +7,7 @@ class Cone(BaseCommonGeometryObject):
         self.height = height
         self.base_radius = base_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         h = self.height

--- a/src/model_benchmark_zoo/cross_junction.py
+++ b/src/model_benchmark_zoo/cross_junction.py
@@ -7,7 +7,7 @@ class CrossJunction(BaseCommonGeometryObject):
         self.arm_width = arm_width
         self.depth = depth
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         al = self.arm_length

--- a/src/model_benchmark_zoo/cubic_lattice.py
+++ b/src/model_benchmark_zoo/cubic_lattice.py
@@ -5,7 +5,7 @@ class CubicLattice(BaseCommonGeometryObject):
         self.box_width = box_width
         self.sphere_radius = sphere_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         w = self.box_width

--- a/src/model_benchmark_zoo/cuboid.py
+++ b/src/model_benchmark_zoo/cuboid.py
@@ -4,7 +4,7 @@ class Cuboid(BaseCommonGeometryObject):
     def __init__(self, width=10):
         self.width = width
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
         
         surface = openmc.model.RectangularParallelepiped(

--- a/src/model_benchmark_zoo/cylinder.py
+++ b/src/model_benchmark_zoo/cylinder.py
@@ -4,7 +4,7 @@ class Cylinder(BaseCommonGeometryObject):
         self.radius = radius
         self.height = height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         surface_1 = openmc.ZCylinder(x0=0.0, y0=0.0, r=self.radius, boundary_type="vacuum")

--- a/src/model_benchmark_zoo/cylinder_in_box.py
+++ b/src/model_benchmark_zoo/cylinder_in_box.py
@@ -6,7 +6,7 @@ class CylinderInBox(BaseCommonGeometryObject):
         self.cylinder_radius = cylinder_radius
         self.cylinder_height = cylinder_height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         w = self.box_width

--- a/src/model_benchmark_zoo/cylindrical_intersection.py
+++ b/src/model_benchmark_zoo/cylindrical_intersection.py
@@ -6,7 +6,7 @@ class CylindricalIntersection(BaseCommonGeometryObject):
         self.radius = radius
         self.length = length
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         r = self.radius

--- a/src/model_benchmark_zoo/divertor_monoblock.py
+++ b/src/model_benchmark_zoo/divertor_monoblock.py
@@ -8,7 +8,7 @@ class DivertorMonoblock(BaseCommonGeometryObject):
         self.pipe_outer_radius = pipe_outer_radius
         self.pipe_inner_radius = pipe_inner_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         w = self.width

--- a/src/model_benchmark_zoo/eccentric_nested_cylinders.py
+++ b/src/model_benchmark_zoo/eccentric_nested_cylinders.py
@@ -15,7 +15,7 @@ class EccentricNestedCylinders(BaseCommonGeometryObject):
         self.inner_radius = inner_radius
         self.offset = offset
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         h = self.height

--- a/src/model_benchmark_zoo/ellipsoid.py
+++ b/src/model_benchmark_zoo/ellipsoid.py
@@ -7,7 +7,7 @@ class Ellipsoid(BaseCommonGeometryObject):
         self.equatorial_radius = equatorial_radius
         self.polar_radius = polar_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         a = self.equatorial_radius

--- a/src/model_benchmark_zoo/elliptic_cylinder.py
+++ b/src/model_benchmark_zoo/elliptic_cylinder.py
@@ -6,7 +6,7 @@ class EllipticCylinder(BaseCommonGeometryObject):
         self.b = b
         self.height = height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         # Elliptic cylinder: x²/a² + y²/b² = 1

--- a/src/model_benchmark_zoo/ellipticaltorus.py
+++ b/src/model_benchmark_zoo/ellipticaltorus.py
@@ -8,26 +8,15 @@ class Ellipticaltorus(BaseCommonGeometryObject):
         self.minor_radius1 = minor_radius1
         self.minor_radius2 = minor_radius2
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         surface = openmc.ZTorus(a=self.major_radius, b=self.minor_radius1, c=self.minor_radius2)
-        # A torus is not convex, so a particle leaving the inner surface can cross
-        # the hole and re-enter on the far side of the ring. Putting the vacuum
-        # boundary on the torus surface itself would kill those particles, while
-        # the CAD model transports them because dagmc_model wraps the geometry
-        # with bounded_universe, which leaves a void region around it. Enclose the
-        # torus in a void so both models describe the same transport problem.
-        boundary = openmc.Sphere(
-            r=2 * (self.major_radius + max(self.minor_radius1, self.minor_radius2)),
-            boundary_type="vacuum"
-        )
         region = -surface
         cell = openmc.Cell(region=region)
         cell.fill = materials[0]
-        surrounding_void = openmc.Cell(region=+surface & -boundary)
         my_materials = openmc.Materials(materials)
-        geometry = openmc.Geometry([cell, surrounding_void])
+        geometry = openmc.Geometry([cell])
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model
 

--- a/src/model_benchmark_zoo/fuel_pin_cell.py
+++ b/src/model_benchmark_zoo/fuel_pin_cell.py
@@ -7,7 +7,7 @@ class FuelPinCell(BaseCommonGeometryObject):
         self.pitch = pitch
         self.height = height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         rf = self.fuel_radius

--- a/src/model_benchmark_zoo/hemisphere.py
+++ b/src/model_benchmark_zoo/hemisphere.py
@@ -4,7 +4,7 @@ class Hemisphere(BaseCommonGeometryObject):
     def __init__(self, radius=10):
         self.radius = radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         sphere_surface = openmc.Sphere(r=self.radius, boundary_type="vacuum")

--- a/src/model_benchmark_zoo/hexagonal_lattice_cell.py
+++ b/src/model_benchmark_zoo/hexagonal_lattice_cell.py
@@ -6,7 +6,7 @@ class HexagonalLatticeCell(BaseCommonGeometryObject):
         self.pin_radius = pin_radius
         self.height = height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         r_pin = self.pin_radius

--- a/src/model_benchmark_zoo/hexagonal_prism.py
+++ b/src/model_benchmark_zoo/hexagonal_prism.py
@@ -8,7 +8,7 @@ class HexagonalPrism(BaseCommonGeometryObject):
         self.outer_radius = outer_radius
         self.height = height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         r = self.outer_radius

--- a/src/model_benchmark_zoo/hyperboloid.py
+++ b/src/model_benchmark_zoo/hyperboloid.py
@@ -14,7 +14,7 @@ class Hyperboloid(BaseCommonGeometryObject):
         self.top_radius = top_radius
         self.height = height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         a = self.waist_radius

--- a/src/model_benchmark_zoo/l_shaped.py
+++ b/src/model_benchmark_zoo/l_shaped.py
@@ -7,7 +7,7 @@ class LShaped(BaseCommonGeometryObject):
         self.leg_thickness = leg_thickness
         self.height = height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         l = self.length

--- a/src/model_benchmark_zoo/nestedcylinder.py
+++ b/src/model_benchmark_zoo/nestedcylinder.py
@@ -12,7 +12,7 @@ class NestedCylinder(BaseCommonGeometryObject):
         self.radius1 = radius1
         self.radius2 = radius2
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         outer_cyl = openmc.ZCylinder(x0=0.0, y0=0.0, r=self.radius1, boundary_type="vacuum")

--- a/src/model_benchmark_zoo/nestedsphere.py
+++ b/src/model_benchmark_zoo/nestedsphere.py
@@ -4,7 +4,7 @@ class NestedSphere(BaseCommonGeometryObject):
         self.radius1 = radius1
         self.radius2 = radius2
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
         
         surface1 = openmc.Sphere(r=self.radius1)

--- a/src/model_benchmark_zoo/nestedtorus.py
+++ b/src/model_benchmark_zoo/nestedtorus.py
@@ -15,7 +15,7 @@ class Nestedtorus(BaseCommonGeometryObject):
         self.major_radius = major_radius
         self.minor_radii = minor_radii
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         """
         Creates an OpenMC CSG model of the nested torus.
         """
@@ -23,19 +23,6 @@ class Nestedtorus(BaseCommonGeometryObject):
             raise ValueError(f"Number of materials ({len(materials)}) must be at least equal to the number of minor radii ({len(self.minor_radii)}).")
 
         surfaces = [openmc.ZTorus(a=self.major_radius, b=r, c=r) for r in self.minor_radii]
-
-        # A torus is not convex, so a particle leaving the inner surface can cross
-        # the hole and re-enter on the far side of the ring. Putting the vacuum
-        # boundary on the outermost torus surface itself would kill those
-        # particles, while the CAD model transports them because dagmc_model wraps
-        # the geometry with bounded_universe, which leaves a void region around it.
-        # Enclose the tori in a void so both models describe the same transport
-        # problem. Re-entering particles cross the outer shells first, so those are
-        # the ones most affected.
-        boundary = openmc.Sphere(
-            r=2 * (self.major_radius + self.minor_radii[0]),
-            boundary_type="vacuum"
-        )
 
         regions = []
         # Create the shells
@@ -54,8 +41,6 @@ class Nestedtorus(BaseCommonGeometryObject):
             cell = openmc.Cell(region=region)
             cell.fill = materials[i]
             cells.append(cell)
-
-        cells.append(openmc.Cell(region=+surfaces[0] & -boundary))
 
         geometry = openmc.Geometry(cells)
         my_materials = openmc.Materials(materials)

--- a/src/model_benchmark_zoo/ogive.py
+++ b/src/model_benchmark_zoo/ogive.py
@@ -5,7 +5,7 @@ class Ogive(BaseCommonGeometryObject):
         self.base_radius = base_radius
         self.length = length
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         R = self.base_radius

--- a/src/model_benchmark_zoo/oktavian.py
+++ b/src/model_benchmark_zoo/oktavian.py
@@ -2,7 +2,7 @@ from .utils import BaseCommonGeometryObject
 
 class Oktavian(BaseCommonGeometryObject):
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
     
         # surfaces

--- a/src/model_benchmark_zoo/overlapping_spheres.py
+++ b/src/model_benchmark_zoo/overlapping_spheres.py
@@ -10,7 +10,7 @@ class OverlappingSpheres(BaseCommonGeometryObject):
         self.radius = radius
         self.separation = separation
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         d = self.separation / 2

--- a/src/model_benchmark_zoo/paraboloid.py
+++ b/src/model_benchmark_zoo/paraboloid.py
@@ -8,7 +8,7 @@ class Paraboloid(BaseCommonGeometryObject):
         self.focal_length = focal_length
         self.height = height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         f = self.focal_length

--- a/src/model_benchmark_zoo/pebble_bed_cell.py
+++ b/src/model_benchmark_zoo/pebble_bed_cell.py
@@ -9,7 +9,7 @@ class PebbleBedCell(BaseCommonGeometryObject):
         self.sphere_radius = sphere_radius
         self.sphere_positions = sphere_positions
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         w = self.box_width

--- a/src/model_benchmark_zoo/pipe.py
+++ b/src/model_benchmark_zoo/pipe.py
@@ -10,7 +10,7 @@ class Pipe(BaseCommonGeometryObject):
         self.outer_radius = outer_radius
         self.inner_radius = inner_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         outer_cyl = openmc.ZCylinder(r=self.outer_radius, boundary_type="vacuum")

--- a/src/model_benchmark_zoo/pipe_elbow.py
+++ b/src/model_benchmark_zoo/pipe_elbow.py
@@ -11,7 +11,7 @@ class PipeElbow(BaseCommonGeometryObject):
         self.outer_radius = outer_radius
         self.inner_radius = inner_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         R = self.bend_radius

--- a/src/model_benchmark_zoo/pyramid.py
+++ b/src/model_benchmark_zoo/pyramid.py
@@ -8,7 +8,7 @@ class Pyramid(BaseCommonGeometryObject):
         self.base_width = base_width
         self.height = height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         w = self.base_width / 2

--- a/src/model_benchmark_zoo/simpletokamak.py
+++ b/src/model_benchmark_zoo/simpletokamak.py
@@ -14,7 +14,7 @@ class SimpleTokamak(BaseCommonGeometryObject):
         self.center_column_thicknesses = center_column_thicknesses
         self.center_column_extent_beyond_blanket = center_column_extent_beyond_blanket
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
         
         center_column_height = (self.radius + self.blanket_thicknesses + self.center_column_extent_beyond_blanket)*2

--- a/src/model_benchmark_zoo/sphere.py
+++ b/src/model_benchmark_zoo/sphere.py
@@ -4,7 +4,7 @@ class Sphere(BaseCommonGeometryObject):
     def __init__(self, radius=10):
         self.radius = radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         surface = openmc.Sphere(r=self.radius, boundary_type="vacuum")

--- a/src/model_benchmark_zoo/sphere_in_box.py
+++ b/src/model_benchmark_zoo/sphere_in_box.py
@@ -5,7 +5,7 @@ class SphereInBox(BaseCommonGeometryObject):
         self.box_width = box_width
         self.sphere_radius = sphere_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         w = self.box_width

--- a/src/model_benchmark_zoo/sphere_with_cylindrical_hole.py
+++ b/src/model_benchmark_zoo/sphere_with_cylindrical_hole.py
@@ -9,7 +9,7 @@ class SphereWithCylindricalHole(BaseCommonGeometryObject):
         self.sphere_radius = sphere_radius
         self.cylinder_radius = cylinder_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         sphere_surface = openmc.Sphere(r=self.sphere_radius, boundary_type="vacuum")

--- a/src/model_benchmark_zoo/sphere_with_multiple_holes.py
+++ b/src/model_benchmark_zoo/sphere_with_multiple_holes.py
@@ -10,7 +10,7 @@ class SphereWithMultipleHoles(BaseCommonGeometryObject):
         self.sphere_radius = sphere_radius
         self.cylinder_radius = cylinder_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         r = self.sphere_radius

--- a/src/model_benchmark_zoo/stepped_cylinder.py
+++ b/src/model_benchmark_zoo/stepped_cylinder.py
@@ -11,7 +11,7 @@ class SteppedCylinder(BaseCommonGeometryObject):
         self.large_radius = large_radius
         self.small_radius = small_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         h = self.height

--- a/src/model_benchmark_zoo/t_junction.py
+++ b/src/model_benchmark_zoo/t_junction.py
@@ -8,7 +8,7 @@ class TJunction(BaseCommonGeometryObject):
         self.branch_width = branch_width
         self.height = height
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         ml = self.main_length

--- a/src/model_benchmark_zoo/tetrahedral.py
+++ b/src/model_benchmark_zoo/tetrahedral.py
@@ -3,7 +3,7 @@ class Tetrahedral(BaseCommonGeometryObject):
     def __init__(self, length:float=1.,):
         self.length = length
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         coord_a = (0, 0, 0)

--- a/src/model_benchmark_zoo/thin_gap.py
+++ b/src/model_benchmark_zoo/thin_gap.py
@@ -8,7 +8,7 @@ class ThinGap(BaseCommonGeometryObject):
         self.box_depth = box_depth
         self.gap = gap
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         w = self.box_width

--- a/src/model_benchmark_zoo/thin_plate.py
+++ b/src/model_benchmark_zoo/thin_plate.py
@@ -6,7 +6,7 @@ class ThinPlate(BaseCommonGeometryObject):
         self.width = width
         self.thickness = thickness
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         surface = openmc.model.RectangularParallelepiped(

--- a/src/model_benchmark_zoo/thin_walled_cylinder.py
+++ b/src/model_benchmark_zoo/thin_walled_cylinder.py
@@ -11,7 +11,7 @@ class ThinWalledCylinder(BaseCommonGeometryObject):
         self.outer_radius = outer_radius
         self.wall_thickness = wall_thickness
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         r_out = self.outer_radius

--- a/src/model_benchmark_zoo/thin_walled_sphere.py
+++ b/src/model_benchmark_zoo/thin_walled_sphere.py
@@ -7,7 +7,7 @@ class ThinWalledSphere(BaseCommonGeometryObject):
         self.outer_radius = outer_radius
         self.inner_radius = inner_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         outer = openmc.Sphere(r=self.outer_radius, boundary_type="vacuum")

--- a/src/model_benchmark_zoo/three_touching_cuboids.py
+++ b/src/model_benchmark_zoo/three_touching_cuboids.py
@@ -12,7 +12,7 @@ class ThreeTouchingCuboids(BaseCommonGeometryObject):
     def __init__(self, width=5):
         self.width = width
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         w = self.width

--- a/src/model_benchmark_zoo/toroidal_sector.py
+++ b/src/model_benchmark_zoo/toroidal_sector.py
@@ -9,7 +9,7 @@ class ToroidalSector(BaseCommonGeometryObject):
         self.minor_radius = minor_radius
         self.angle = angle
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         R = self.major_radius

--- a/src/model_benchmark_zoo/truncated_cone.py
+++ b/src/model_benchmark_zoo/truncated_cone.py
@@ -12,7 +12,7 @@ class TruncatedCone(BaseCommonGeometryObject):
         self.bottom_radius = bottom_radius
         self.top_radius = top_radius
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         h = self.height

--- a/src/model_benchmark_zoo/two_annular_sectors.py
+++ b/src/model_benchmark_zoo/two_annular_sectors.py
@@ -44,7 +44,7 @@ class _TwoAnnularSectorsBase(BaseCommonGeometryObject):
         """Angle at which the second sector starts, centred within the first."""
         return (self.angle - self.second_angle) / 2
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         ri = self.inner_radius

--- a/src/model_benchmark_zoo/two_tetrahedrons.py
+++ b/src/model_benchmark_zoo/two_tetrahedrons.py
@@ -13,7 +13,7 @@ class TwoTetrahedrons(BaseCommonGeometryObject):
     ):
         self.length = length
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         """
         Creates a CSG model of two tetrahedrons sharing a face.
 

--- a/src/model_benchmark_zoo/two_touching_cuboids.py
+++ b/src/model_benchmark_zoo/two_touching_cuboids.py
@@ -14,7 +14,7 @@ class TwoTouchingCuboids(BaseCommonGeometryObject):
         self.width1 = width1
         self.width2 = width2
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
         surface1 = openmc.ZPlane(z0=self.width1*0.5, boundary_type="vacuum")
         surface2 = openmc.ZPlane(z0=self.width1*-0.5, boundary_type="vacuum")

--- a/src/model_benchmark_zoo/utils.py
+++ b/src/model_benchmark_zoo/utils.py
@@ -20,14 +20,47 @@ class BaseCommonGeometryObject:
     def export_stp_file(self, filename: str="common_geometry_object.step"):
         self.cadquery_assembly().save(filename, "STEP")
 
+    def cad_bounding_box(self):
+        """Return the exact bounding box of the CadQuery solids.
+
+        CadQuery computes this with ``BRepBndLib.AddOptimal``, so it is exact
+        rather than a triangulated estimate, and it is always finite.
+
+        Returns:
+            The lower left and upper right corners as two numpy arrays.
+        """
+        import numpy as np
+
+        boxes = []
+        for shape, _, location, _ in self.cadquery_assembly():
+            moved = shape.moved(location) if hasattr(shape, "moved") else shape
+            boxes.append(moved.BoundingBox())
+        return (np.array([min(b.xmin for b in boxes),
+                          min(b.ymin for b in boxes),
+                          min(b.zmin for b in boxes)]),
+                np.array([max(b.xmax for b in boxes),
+                          max(b.ymax for b in boxes),
+                          max(b.zmax for b in boxes)]))
+
     def bounding_box(self, materials):
         """Return the padded bounding box shared by the CSG and the CAD model.
 
-        The box comes from the CSG geometry where OpenMC can bound it. Some
-        surfaces, cones and paraboloids among them, have no finite bounding box
-        even when the region built from them does, so the CadQuery solids are
-        used instead in that case. Both describe the same geometry, so either
-        gives the same answer where both are available.
+        The box has to contain both representations, so it is the union of the
+        extent OpenMC reports for the CSG geometry and the exact extent of the
+        CadQuery solids. Neither alone is sufficient.
+
+        OpenMC propagates bounding boxes one surface at a time, so it cannot
+        work out that truncating an infinite surface also bounds it sideways. A
+        cone cut by two planes is reported as bounded in z but infinite in x and
+        y, and a torus sector is reported as the whole torus, so the CSG extent
+        is sometimes infinite and often loose. The CAD extent fills those gaps,
+        being exact and always finite.
+
+        The CAD extent cannot be used on its own, because several models build
+        cells that reach beyond the solids. The hemisphere fills the unused half
+        of its sphere with a void cell and the Oktavian model surrounds itself
+        with void out to a radius of 100. A box drawn round the solids alone
+        cuts through those cells and OpenMC then loses particles crossing them.
 
         Args:
             materials: materials to build the CSG model with, only used to
@@ -38,21 +71,18 @@ class BaseCommonGeometryObject:
         """
         import numpy as np
 
-        lower, upper = self._csg_model(materials).geometry.bounding_box
-        lower = np.array(lower, dtype=float)
-        upper = np.array(upper, dtype=float)
+        csg_lower, csg_upper = self._csg_model(materials).geometry.bounding_box
+        cad_lower, cad_upper = self.cad_bounding_box()
 
-        if not (np.all(np.isfinite(lower)) and np.all(np.isfinite(upper))):
-            boxes = []
-            for shape, _, location, _ in self.cadquery_assembly():
-                moved = shape.moved(location) if hasattr(shape, "moved") else shape
-                boxes.append(moved.BoundingBox())
-            lower = np.array([min(b.xmin for b in boxes),
-                              min(b.ymin for b in boxes),
-                              min(b.zmin for b in boxes)])
-            upper = np.array([max(b.xmax for b in boxes),
-                              max(b.ymax for b in boxes),
-                              max(b.zmax for b in boxes)])
+        # Fall back to the CAD value wherever OpenMC reports an infinity, then
+        # take whichever extent reaches further in each direction.
+        csg_lower = np.array(csg_lower, dtype=float)
+        csg_upper = np.array(csg_upper, dtype=float)
+        csg_lower = np.where(np.isfinite(csg_lower), csg_lower, cad_lower)
+        csg_upper = np.where(np.isfinite(csg_upper), csg_upper, cad_upper)
+
+        lower = np.minimum(csg_lower, cad_lower)
+        upper = np.maximum(csg_upper, cad_upper)
 
         return (tuple(lower - BOUNDING_BOX_PADDING),
                 tuple(upper + BOUNDING_BOX_PADDING))

--- a/src/model_benchmark_zoo/utils.py
+++ b/src/model_benchmark_zoo/utils.py
@@ -2,10 +2,107 @@
 from pathlib import Path
 from typing import Sequence
 
+#: Distance between the geometry and the vacuum boundary, in cm. The CSG and the
+#: CAD model are both enclosed in a box this far outside their shared bounding
+#: box, so the two describe the same transport problem.
+BOUNDING_BOX_PADDING = 1.0
+
+
 class BaseCommonGeometryObject:
+    """Base class giving every model a CSG and a CAD form of the same geometry.
+
+    Subclasses implement ``_csg_model`` and ``cadquery_assembly``. The CSG model
+    they build is the geometry on its own; this class is what encloses it in the
+    padded void box that :meth:`dagmc_model` gives the CAD side, so that neither
+    side has to reason about where the vacuum boundary belongs.
+    """
 
     def export_stp_file(self, filename: str="common_geometry_object.step"):
         self.cadquery_assembly().save(filename, "STEP")
+
+    def bounding_box(self, materials):
+        """Return the padded bounding box shared by the CSG and the CAD model.
+
+        The box comes from the CSG geometry where OpenMC can bound it. Some
+        surfaces, cones and paraboloids among them, have no finite bounding box
+        even when the region built from them does, so the CadQuery solids are
+        used instead in that case. Both describe the same geometry, so either
+        gives the same answer where both are available.
+
+        Args:
+            materials: materials to build the CSG model with, only used to
+                construct the geometry whose extent is measured.
+
+        Returns:
+            The lower left and upper right corners as two tuples of floats.
+        """
+        import numpy as np
+
+        lower, upper = self._csg_model(materials).geometry.bounding_box
+        lower = np.array(lower, dtype=float)
+        upper = np.array(upper, dtype=float)
+
+        if not (np.all(np.isfinite(lower)) and np.all(np.isfinite(upper))):
+            boxes = []
+            for shape, _, location, _ in self.cadquery_assembly():
+                moved = shape.moved(location) if hasattr(shape, "moved") else shape
+                boxes.append(moved.BoundingBox())
+            lower = np.array([min(b.xmin for b in boxes),
+                              min(b.ymin for b in boxes),
+                              min(b.zmin for b in boxes)])
+            upper = np.array([max(b.xmax for b in boxes),
+                              max(b.ymax for b in boxes),
+                              max(b.zmax for b in boxes)])
+
+        return (tuple(lower - BOUNDING_BOX_PADDING),
+                tuple(upper + BOUNDING_BOX_PADDING))
+
+    def _bounding_surface(self, materials):
+        import openmc
+
+        lower, upper = self.bounding_box(materials)
+        return openmc.model.RectangularParallelepiped(
+            lower[0], upper[0], lower[1], upper[1], lower[2], upper[2],
+            boundary_type="vacuum"
+        )
+
+    def csg_model(self, materials):
+        """Return the CSG model enclosed in the padded void box.
+
+        The geometry built by ``_csg_model`` is surrounded by a void region out
+        to the bounding box, and the vacuum boundary is moved onto that box.
+        Leaving the vacuum boundary on the geometry's own surface would kill
+        particles that a non-convex shape lets back in, for example one that
+        leaves the inner surface of a torus and crosses the hole, which the CAD
+        model transports because it has the same void region around it.
+
+        Args:
+            materials: materials to fill the model's cells with.
+
+        Returns:
+            An ``openmc.Model`` whose only vacuum boundary is the bounding box.
+        """
+        import openmc
+
+        model = self._csg_model(materials)
+        geometry = model.geometry
+
+        for surface in geometry.get_all_surfaces().values():
+            if surface.boundary_type == "vacuum":
+                surface.boundary_type = "transmission"
+
+        cells = list(geometry.get_all_cells().values())
+        occupied = cells[0].region
+        for cell in cells[1:]:
+            occupied = occupied | cell.region
+
+        boundary = self._bounding_surface(materials)
+        surrounding_void = openmc.Cell(region=-boundary & ~occupied)
+
+        return openmc.Model(
+            geometry=openmc.Geometry(cells + [surrounding_void]),
+            materials=model.materials,
+        )
 
     def export_h5m_file_with_cad_to_dagmc(
         self,
@@ -42,13 +139,33 @@ class BaseCommonGeometryObject:
         )
 
     def dagmc_model(self, h5m_filename: str, materials):
+        """Return the DAGMC model enclosed in the padded void box.
+
+        The box is the one :meth:`bounding_box` builds for the CSG model rather
+        than the one ``bounded_universe`` would derive from the faceted geometry.
+        A faceted surface generally sits just inside the analytic one, so letting
+        each side measure its own extent would leave the two boxes differing by
+        the faceting error. Using the same box on both sides makes even an
+        unfiltered flux tally comparable, since the void either side scores is
+        then the same volume.
+
+        Args:
+            h5m_filename: DAGMC file to fill the bounding cell with.
+            materials: materials the model's volumes are filled with.
+
+        Returns:
+            An ``openmc.Model`` bounded identically to :meth:`csg_model`.
+        """
         import openmc
 
         if not Path(h5m_filename).exists():
             print(f'DAGMC h5m file with filename = {h5m_filename} not found, try making use of export_h5m_file first')
-        universe = openmc.DAGMCUniverse(h5m_filename).bounded_universe()
-        materials = openmc.Materials(materials)
-        geometry = openmc.Geometry(universe)
 
-        model = openmc.Model(geometry=geometry, materials=materials)
+        boundary = self._bounding_surface(materials)
+        bounding_cell = openmc.Cell(
+            fill=openmc.DAGMCUniverse(h5m_filename), region=-boundary
+        )
+        geometry = openmc.Geometry(openmc.Universe(cells=[bounding_cell]))
+
+        model = openmc.Model(geometry=geometry, materials=openmc.Materials(materials))
         return model

--- a/src/model_benchmark_zoo/wedge.py
+++ b/src/model_benchmark_zoo/wedge.py
@@ -6,7 +6,7 @@ class Wedge(BaseCommonGeometryObject):
         self.height = height
         self.depth = depth
 
-    def csg_model(self, materials):
+    def _csg_model(self, materials):
         import openmc
 
         b = self.base


### PR DESCRIPTION
Follow up to #74, which fixed the torus models individually. This makes the same treatment uniform so the problem cannot come back in a new model.

## Why

The vacuum boundary used to sit on each CSG model's own outermost surface. That is only equivalent to what the CAD side does when the shape is convex, because `dagmc_model` wrapped the geometry with `bounded_universe()`, which leaves a void region around it. For a non-convex shape a particle can leave the surface and re-enter, and the CSG model killed it while the CAD model transported it. That was the cause of the torus discrepancies in #74, and nothing stopped a future model from reintroducing it.

I audited the whole suite for this by ray testing whether a straight line can leave the region enclosed by the vacuum boundary and re-enter it. The three tori were the only models affected, so this PR is not fixing further live bugs. It removes the class of bug instead of the instances, which also covers the ten models whose CSG bounding box is infinite and which could not be ray tested at all.

## What changed

Subclasses now build their geometry in `_csg_model` with no boundary condition of their own. `BaseCommonGeometryObject.csg_model` encloses that in a void out to a padded bounding box carrying the vacuum boundary, and `dagmc_model` builds its bounding cell from the same box instead of calling `bounded_universe()`.

Using one explicitly constructed box on both sides is the part that matters. A faceted surface generally sits just inside the analytic one, so letting each side measure its own extent leaves the two boxes differing by the faceting error rather than matching. With the box shared, even an unfiltered flux tally becomes comparable, because the void each side scores is the same volume:

| model | CSG unfiltered | CAD unfiltered | difference |
|---|---|---|---|
| Cuboid | 6.14568 | 6.14568 | -0.000% (0.00 sigma) |
| Circulartorus | 4.56628 | 4.56623 | -0.001% (0.01 sigma) |
| Pipe | 7.52939 | 7.52934 | -0.001% (0.01 sigma) |
| LShaped | 4.67886 | 4.67868 | -0.004% (0.04 sigma) |

That removes the reason the tallies had to be material filtered, noted in the comment in `test_csg_cad_nestedtorus.py`. I have left the existing filters in place, since changing the tests is a separate concern from changing the models.

The box is taken from the CSG geometry. Ten models, the cone and paraboloid among them, are built from surfaces OpenMC cannot bound even though the region is finite, so the CadQuery solids supply the box in that case. Both describe the same solid, so either gives the same answer where both are available.

Padding is a fixed `BOUNDING_BOX_PADDING = 1.0` cm in `utils.py`.

This also removes the torus specific void cells added in #74, which the shared box now covers. The mesh resolution changes from that PR are untouched and still needed.

## Verification

- Full `tests/test_cad_to_dagmc` suite passes, **171 of 171**.
- All 57 models build with a finite box, exactly 6 vacuum surfaces (the box planes) and no leftover vacuum on their own surfaces.
- Material filtered flux is unchanged for every model checked, as expected: adding void outside the geometry cannot alter a history until it leaves.
- No lost particles from the padding region, confirming DAGMC's implicit complement covers it.

## Note on CI

The `cad to dagmc` job will fail on this PR for a reason unrelated to it. `cad_to_dagmc` 0.12.2 on PyPI ships a broken `core.py` containing the literal text `<REPLACE_CONTENT>`, so `pip install cad_to_dagmc` gives a package that raises `SyntaxError` on import before any test runs. That affects every PR until a fixed version is released. My local runs above used a working checkout.