### PR TITLE
Remove the model defined void cells and tighten the bounding box

### DIFF
--- a/src/model_benchmark_zoo/annular_sector.py
+++ b/src/model_benchmark_zoo/annular_sector.py
@@ -24,12 +24,10 @@ class AnnularSector(BaseCommonGeometryObject):
         y_plane = openmc.YPlane(y0=0, boundary_type="vacuum")
 
         region_material = +inner_cyl & -outer_cyl & +z_bot & -z_top & +x_plane & +y_plane
-        region_void = -inner_cyl & +z_bot & -z_top & +x_plane & +y_plane
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/box_with_spherical_cavity.py
+++ b/src/model_benchmark_zoo/box_with_spherical_cavity.py
@@ -24,12 +24,10 @@ class BoxWithSphericalCavity(BaseCommonGeometryObject):
         sphere_surface = openmc.Sphere(r=self.sphere_radius)
 
         region_material = -box_surface & +sphere_surface
-        region_cavity = -box_surface & -sphere_surface
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_cavity)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/capsule.py
+++ b/src/model_benchmark_zoo/capsule.py
@@ -30,18 +30,12 @@ class Capsule(BaseCommonGeometryObject):
         )
 
         # Bounding surfaces
-        bound_cyl = openmc.ZCylinder(r=r + 1, boundary_type="vacuum")
-        z_top = openmc.ZPlane(z0=h / 2 + r + 1, boundary_type="vacuum")
-        z_bot = openmc.ZPlane(z0=-(h / 2 + r + 1), boundary_type="vacuum")
 
-        bounding = -bound_cyl & -z_top & +z_bot
 
-        region_void = bounding & ~region_material
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/cone.py
+++ b/src/model_benchmark_zoo/cone.py
@@ -17,15 +17,12 @@ class Cone(BaseCommonGeometryObject):
         cone = openmc.ZCone(z0=h / 2, r2=(r / h) ** 2)
         z_top = openmc.ZPlane(z0=h / 2, boundary_type="vacuum")
         z_bot = openmc.ZPlane(z0=-h / 2, boundary_type="vacuum")
-        outer_cyl = openmc.ZCylinder(r=r, boundary_type="vacuum")
 
         region_material = -cone & +z_bot & -z_top
-        region_void = +cone & -outer_cyl & +z_bot & -z_top
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/cross_junction.py
+++ b/src/model_benchmark_zoo/cross_junction.py
@@ -1,6 +1,5 @@
 from .utils import BaseCommonGeometryObject
 
-
 class CrossJunction(BaseCommonGeometryObject):
     def __init__(self, arm_length=10, arm_width=4, depth=4):
         self.arm_length = arm_length
@@ -37,18 +36,11 @@ class CrossJunction(BaseCommonGeometryObject):
         region_v_bot = +x_bar_min & -x_bar_max & +y_min & -y_bar_min & +z_bot & -z_top
 
         # Four corner void regions
-        region_void_1 = +x_bar_max & -x_max & +y_bar_max & -y_max & +z_bot & -z_top
-        region_void_2 = +x_min & -x_bar_min & +y_bar_max & -y_max & +z_bot & -z_top
-        region_void_3 = +x_min & -x_bar_min & +y_min & -y_bar_min & +z_bot & -z_top
-        region_void_4 = +x_bar_max & -x_max & +y_min & -y_bar_min & +z_bot & -z_top
 
         cell1 = openmc.Cell(region=region_h, fill=materials[0])
         cell2 = openmc.Cell(region=region_v_top | region_v_bot, fill=materials[1])
-        cell3 = openmc.Cell(
-            region=region_void_1 | region_void_2 | region_void_3 | region_void_4
-        )
 
-        geometry = openmc.Geometry([cell1, cell2, cell3])
+        geometry = openmc.Geometry([cell1, cell2])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/cylindrical_intersection.py
+++ b/src/model_benchmark_zoo/cylindrical_intersection.py
@@ -1,6 +1,5 @@
 from .utils import BaseCommonGeometryObject
 
-
 class CylindricalIntersection(BaseCommonGeometryObject):
     def __init__(self, radius=3, length=20):
         self.radius = radius
@@ -29,12 +28,10 @@ class CylindricalIntersection(BaseCommonGeometryObject):
         region_mat = bounding & (-z_cyl | -x_cyl)
 
         # Void: inside bounding, outside both cylinders
-        region_void = bounding & +z_cyl & +x_cyl
 
         cell1 = openmc.Cell(region=region_mat, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/divertor_monoblock.py
+++ b/src/model_benchmark_zoo/divertor_monoblock.py
@@ -26,13 +26,11 @@ class DivertorMonoblock(BaseCommonGeometryObject):
 
         region_block = -box & +outer_pipe
         region_pipe = -outer_pipe & +inner_pipe & -box
-        region_void = -inner_pipe & -box
 
         cell1 = openmc.Cell(region=region_block, fill=materials[0])
         cell2 = openmc.Cell(region=region_pipe, fill=materials[1])
-        cell3 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2, cell3])
+        geometry = openmc.Geometry([cell1, cell2])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/ellipsoid.py
+++ b/src/model_benchmark_zoo/ellipsoid.py
@@ -22,12 +22,10 @@ class Ellipsoid(BaseCommonGeometryObject):
         bounding_sphere = openmc.Sphere(r=max(a, c) + 1, boundary_type="vacuum")
 
         region_material = -surface & -bounding_sphere
-        region_void = +surface & -bounding_sphere
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/hemisphere.py
+++ b/src/model_benchmark_zoo/hemisphere.py
@@ -13,10 +13,8 @@ class Hemisphere(BaseCommonGeometryObject):
         hemisphere_region = -sphere_surface & +z_plane
         hemisphere_cell = openmc.Cell(region=hemisphere_region, fill=materials[0])
 
-        void_region = -sphere_surface & -z_plane
-        void_cell = openmc.Cell(region=void_region)
 
-        geometry = openmc.Geometry([hemisphere_cell, void_cell])
+        geometry = openmc.Geometry([hemisphere_cell])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/hyperboloid.py
+++ b/src/model_benchmark_zoo/hyperboloid.py
@@ -32,15 +32,12 @@ class Hyperboloid(BaseCommonGeometryObject):
 
         z_top = openmc.ZPlane(z0=0.5 * self.height, boundary_type="vacuum")
         z_bot = openmc.ZPlane(z0=-0.5 * self.height, boundary_type="vacuum")
-        outer_cyl = openmc.ZCylinder(r=self.top_radius, boundary_type="vacuum")
 
         region_material = -quadric & +z_bot & -z_top
-        region_void = +quadric & -outer_cyl & +z_bot & -z_top
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/l_shaped.py
+++ b/src/model_benchmark_zoo/l_shaped.py
@@ -40,10 +40,8 @@ class LShaped(BaseCommonGeometryObject):
         cell = openmc.Cell(region=region, fill=materials[0])
 
         # Void region: the notch area
-        region_notch = +x_v_right & -x_h_right & +y_h_top & -y_v_top & +z_bot & -z_top
-        cell_void = openmc.Cell(region=region_notch)
 
-        geometry = openmc.Geometry([cell, cell_void])
+        geometry = openmc.Geometry([cell])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/ogive.py
+++ b/src/model_benchmark_zoo/ogive.py
@@ -17,15 +17,12 @@ class Ogive(BaseCommonGeometryObject):
         ogive_sphere = openmc.Sphere(z0=z_c, r=rho)
         z_base = openmc.ZPlane(z0=0, boundary_type="vacuum")
         z_tip = openmc.ZPlane(z0=L, boundary_type="vacuum")
-        outer_cyl = openmc.ZCylinder(r=rho + 1, boundary_type="vacuum")
 
         region_material = -ogive_sphere & +z_base & -z_tip
-        region_void = +ogive_sphere & +z_base & -z_tip & -outer_cyl
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/oktavian.py
+++ b/src/model_benchmark_zoo/oktavian.py
@@ -12,25 +12,20 @@ class Oktavian(BaseCommonGeometryObject):
         surf_4 = openmc.Sphere(surface_id=4, x0=0.0, y0=0.0, z0=0.0, r=10.2)
         surf_5 = openmc.Sphere(surface_id=5, x0=0.0, y0=0.0, z0=0.0, r=19.75)
         surf_6 = openmc.Sphere(surface_id=6, x0=0.0, y0=0.0, z0=0.0, r=19.95)
-        surf_7 = openmc.Sphere(surface_id=7, x0=0.0, y0=0.0, z0=0.0, r=100.0, boundary_type="vacuum")
         surf_8 = openmc.XPlane(surface_id=8, x0=8.32)
 
         # regions
-        region_1 = (-surf_3 & -surf_8) | (+surf_8 & -surf_1 & -surf_6)
         region_2 = (+surf_3 & -surf_4 & -surf_8) | (+surf_8 & +surf_1 & -surf_2 & -surf_6)
         region_3 = (+surf_4 & -surf_5 & -surf_8) | (+surf_8 & +surf_2 & -surf_5)
         region_4 = (+surf_5 & -surf_6 & -surf_8) | (+surf_8 & +surf_2 & +surf_5 & -surf_6)
-        region_5 = +surf_6 & -surf_7
 
         # cells
-        cell_1 = openmc.Cell(cell_id=1, region=region_1, fill=None)
         cell_2 = openmc.Cell(cell_id=2, region=region_2, fill=materials[1])
         cell_3 = openmc.Cell(cell_id=3, region=region_3, fill=materials[0])
         cell_4 = openmc.Cell(cell_id=4, region=region_4, fill=materials[1])
-        cell_5 = openmc.Cell(cell_id=5, region=region_5, fill=None)
 
         # create geometry instance
-        geometry = openmc.Geometry([cell_1, cell_2, cell_3, cell_4, cell_5])
+        geometry = openmc.Geometry([cell_2, cell_3, cell_4])
         my_materials = openmc.Materials([materials[0], materials[1]])
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/overlapping_spheres.py
+++ b/src/model_benchmark_zoo/overlapping_spheres.py
@@ -1,6 +1,5 @@
 from .utils import BaseCommonGeometryObject
 
-
 class OverlappingSpheres(BaseCommonGeometryObject):
     def __init__(self, radius=5, separation=6):
 
@@ -18,20 +17,17 @@ class OverlappingSpheres(BaseCommonGeometryObject):
 
         sphere1 = openmc.Sphere(x0=-d, r=r)
         sphere2 = openmc.Sphere(x0=d, r=r)
-        bounding = openmc.Sphere(r=r + d + 1, boundary_type="vacuum")
 
         # Sphere 1 (including overlap region): mat1
         region1 = -sphere1
         # Sphere 2 minus sphere 1: mat2
         region2 = -sphere2 & +sphere1
         # Void outside both
-        region_void = -bounding & +sphere1 & +sphere2
 
         cell1 = openmc.Cell(region=region1, fill=materials[0])
         cell2 = openmc.Cell(region=region2, fill=materials[1])
-        cell3 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2, cell3])
+        geometry = openmc.Geometry([cell1, cell2])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/paraboloid.py
+++ b/src/model_benchmark_zoo/paraboloid.py
@@ -2,7 +2,6 @@ import math
 
 from .utils import BaseCommonGeometryObject
 
-
 class Paraboloid(BaseCommonGeometryObject):
     def __init__(self, focal_length=5, height=10):
         self.focal_length = focal_length
@@ -13,7 +12,6 @@ class Paraboloid(BaseCommonGeometryObject):
 
         f = self.focal_length
         h = self.height
-        rim_radius = math.sqrt(2 * f * h)
 
         # Paraboloid surface: x² + y² - 2fz = 0
         # -quadric is where x² + y² - 2fz < 0, i.e. z > (x²+y²)/(2f) (above the surface)
@@ -21,17 +19,14 @@ class Paraboloid(BaseCommonGeometryObject):
 
         z_top = openmc.ZPlane(z0=h, boundary_type="vacuum")
         z_bot = openmc.ZPlane(z0=-0.01, boundary_type="vacuum")
-        outer_cyl = openmc.ZCylinder(r=rim_radius, boundary_type="vacuum")
 
         # Material region: inside the paraboloid surface and below the cap
         region_material = -quadric & -z_top & +z_bot
         # Void region: outside the paraboloid but inside the bounding box
-        region_void = +quadric & -z_top & +z_bot & -outer_cyl
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/pipe.py
+++ b/src/model_benchmark_zoo/pipe.py
@@ -19,12 +19,10 @@ class Pipe(BaseCommonGeometryObject):
         z_bot = openmc.ZPlane(z0=-0.5 * self.height, boundary_type="vacuum")
 
         region_wall = -outer_cyl & +inner_cyl & +z_bot & -z_top
-        region_hole = -inner_cyl & +z_bot & -z_top
 
         cell1 = openmc.Cell(region=region_wall, fill=materials[0])
-        cell2 = openmc.Cell(region=region_hole)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/pipe_elbow.py
+++ b/src/model_benchmark_zoo/pipe_elbow.py
@@ -1,6 +1,5 @@
 from .utils import BaseCommonGeometryObject
 
-
 class PipeElbow(BaseCommonGeometryObject):
     def __init__(self, bend_radius=10, outer_radius=3, inner_radius=2):
 
@@ -25,21 +24,11 @@ class PipeElbow(BaseCommonGeometryObject):
         x_plane = openmc.XPlane(x0=0)
         y_plane = openmc.YPlane(y0=0)
 
-        # Bounding
-        outer_cyl = openmc.ZCylinder(r=R + r_out + 1, boundary_type="vacuum")
-        z_top = openmc.ZPlane(z0=r_out + 1, boundary_type="vacuum")
-        z_bot = openmc.ZPlane(z0=-(r_out + 1), boundary_type="vacuum")
-
         region_wall = -outer_torus & +inner_torus & +x_plane & +y_plane
-        region_void = (
-            -outer_cyl & +z_bot & -z_top
-            & (+outer_torus | -inner_torus | -x_plane | -y_plane)
-        )
 
         cell1 = openmc.Cell(region=region_wall, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/pyramid.py
+++ b/src/model_benchmark_zoo/pyramid.py
@@ -2,7 +2,6 @@ import math
 
 from .utils import BaseCommonGeometryObject
 
-
 class Pyramid(BaseCommonGeometryObject):
     def __init__(self, base_width=10, height=10):
         self.base_width = base_width
@@ -31,12 +30,10 @@ class Pyramid(BaseCommonGeometryObject):
         my = openmc.Plane(a=0, b=-h, c=w, d=w * h / 2)
 
         region_material = -box & -px & -mx & -py & -my
-        region_void = -box & (+px | +mx | +py | +my)
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/simpletokamak.py
+++ b/src/model_benchmark_zoo/simpletokamak.py
@@ -24,21 +24,16 @@ class SimpleTokamak(BaseCommonGeometryObject):
         surface_center_cylinder = openmc.ZCylinder(r=self.center_column_thicknesses)
         surface_top_cy = openmc.ZPlane(z0=center_column_height/2, boundary_type='vacuum')
         surface_bot_cy = openmc.ZPlane(z0=-center_column_height/2, boundary_type='vacuum')
-        outer_surface = openmc.ZCylinder(r=self.radius + self.blanket_thicknesses, boundary_type='vacuum')
         
-        region1 = -surface_inner_wall & +surface_center_cylinder  # plasma
         region2 = +surface_inner_wall & -surface_outer_wall & +surface_center_cylinder # blanket
         region3 = -surface_top_cy & +surface_bot_cy & -surface_center_cylinder  # center column
-        region4 = +surface_outer_wall & -surface_top_cy & +surface_bot_cy & +surface_center_cylinder & -outer_surface  # outer vessel
 
-        cell1 = openmc.Cell(region=region1) # plasma
         cell2 = openmc.Cell(region=region2) # blanket
         cell2.fill = materials[0]
         cell3 = openmc.Cell(region=region3) # center column
         cell3.fill = materials[1]
-        cell4 = openmc.Cell(region=region4) # outer vessel
 
-        geometry = openmc.Geometry([cell1, cell2, cell3, cell4])
+        geometry = openmc.Geometry([cell2, cell3])
         materials = openmc.Materials([materials[0], materials[1]])
         model = openmc.Model(geometry=geometry, materials=materials)
         return model

--- a/src/model_benchmark_zoo/sphere_with_cylindrical_hole.py
+++ b/src/model_benchmark_zoo/sphere_with_cylindrical_hole.py
@@ -16,12 +16,10 @@ class SphereWithCylindricalHole(BaseCommonGeometryObject):
         cylinder_surface = openmc.ZCylinder(r=self.cylinder_radius)
 
         region_material = -sphere_surface & +cylinder_surface
-        region_hole = -sphere_surface & -cylinder_surface
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_hole)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/sphere_with_multiple_holes.py
+++ b/src/model_benchmark_zoo/sphere_with_multiple_holes.py
@@ -1,6 +1,5 @@
 from .utils import BaseCommonGeometryObject
 
-
 class SphereWithMultipleHoles(BaseCommonGeometryObject):
     def __init__(self, sphere_radius=10, cylinder_radius=2):
 
@@ -22,12 +21,10 @@ class SphereWithMultipleHoles(BaseCommonGeometryObject):
         z_cyl = openmc.ZCylinder(r=cr)
 
         region_material = -sphere & +x_cyl & +y_cyl & +z_cyl
-        region_holes = -sphere & (-x_cyl | -y_cyl | -z_cyl)
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_holes)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/stepped_cylinder.py
+++ b/src/model_benchmark_zoo/stepped_cylinder.py
@@ -1,6 +1,5 @@
 from .utils import BaseCommonGeometryObject
 
-
 class SteppedCylinder(BaseCommonGeometryObject):
     def __init__(self, height=20, large_radius=6, small_radius=3):
 
@@ -28,12 +27,10 @@ class SteppedCylinder(BaseCommonGeometryObject):
         region_material = region_lower | region_upper
 
         # Void: upper half, between small and large cylinder
-        region_void = +small_cyl & -large_cyl & +z_mid & -z_top
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/t_junction.py
+++ b/src/model_benchmark_zoo/t_junction.py
@@ -36,17 +36,10 @@ class TJunction(BaseCommonGeometryObject):
         # Branch: narrow, above interface
         region_branch = +x_branch_left & -x_branch_right & +y_interface & -y_top & +z_bot & -z_top
 
-        # Void: above interface, to the left of branch
-        region_void_left = +x_left & -x_branch_left & +y_interface & -y_top & +z_bot & -z_top
-        # Void: above interface, to the right of branch
-        region_void_right = +x_branch_right & -x_right & +y_interface & -y_top & +z_bot & -z_top
-
         cell1 = openmc.Cell(region=region_main, fill=materials[0])
         cell2 = openmc.Cell(region=region_branch, fill=materials[1])
-        cell3 = openmc.Cell(region=region_void_left)
-        cell4 = openmc.Cell(region=region_void_right)
 
-        geometry = openmc.Geometry([cell1, cell2, cell3, cell4])
+        geometry = openmc.Geometry([cell1, cell2])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/thin_gap.py
+++ b/src/model_benchmark_zoo/thin_gap.py
@@ -1,6 +1,5 @@
 from .utils import BaseCommonGeometryObject
 
-
 class ThinGap(BaseCommonGeometryObject):
     def __init__(self, box_width=10, box_height=10, box_depth=10, gap=0.5):
         self.box_width = box_width
@@ -28,14 +27,13 @@ class ThinGap(BaseCommonGeometryObject):
         yz_region = +y_min & -y_max & +z_min & -z_max
 
         region_left = +x_min & -x_left & yz_region
-        region_gap = +x_left & -x_right & yz_region
         region_right = +x_right & -x_max & yz_region
 
         cell1 = openmc.Cell(region=region_left, fill=materials[0])
-        cell2 = openmc.Cell(region=region_gap)  # void gap
+  # void gap
         cell3 = openmc.Cell(region=region_right, fill=materials[1])
 
-        geometry = openmc.Geometry([cell1, cell2, cell3])
+        geometry = openmc.Geometry([cell1, cell3])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/thin_walled_cylinder.py
+++ b/src/model_benchmark_zoo/thin_walled_cylinder.py
@@ -1,6 +1,5 @@
 from .utils import BaseCommonGeometryObject
 
-
 class ThinWalledCylinder(BaseCommonGeometryObject):
     def __init__(self, height=20, outer_radius=5, wall_thickness=0.2):
 
@@ -23,12 +22,10 @@ class ThinWalledCylinder(BaseCommonGeometryObject):
         z_bot = openmc.ZPlane(z0=-self.height / 2, boundary_type="vacuum")
 
         region_wall = -outer_cyl & +inner_cyl & +z_bot & -z_top
-        region_hole = -inner_cyl & +z_bot & -z_top
 
         cell1 = openmc.Cell(region=region_wall, fill=materials[0])
-        cell2 = openmc.Cell(region=region_hole)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/thin_walled_sphere.py
+++ b/src/model_benchmark_zoo/thin_walled_sphere.py
@@ -14,12 +14,10 @@ class ThinWalledSphere(BaseCommonGeometryObject):
         inner = openmc.Sphere(r=self.inner_radius)
 
         region_wall = -outer & +inner
-        region_void = -inner
 
         cell1 = openmc.Cell(region=region_wall, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/three_touching_cuboids.py
+++ b/src/model_benchmark_zoo/three_touching_cuboids.py
@@ -33,14 +33,12 @@ class ThreeTouchingCuboids(BaseCommonGeometryObject):
         # mat3: bottom-left
         region3 = +x_left & -x_mid & +y_bot & -y_mid & +z_bot & -z_top
         # void: bottom-right (source location)
-        region4 = +x_mid & -x_right & +y_bot & -y_mid & +z_bot & -z_top
 
         cell1 = openmc.Cell(region=region1, fill=materials[0])
         cell2 = openmc.Cell(region=region2, fill=materials[1])
         cell3 = openmc.Cell(region=region3, fill=materials[2])
-        cell4 = openmc.Cell(region=region4)
 
-        geometry = openmc.Geometry([cell1, cell2, cell3, cell4])
+        geometry = openmc.Geometry([cell1, cell2, cell3])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/toroidal_sector.py
+++ b/src/model_benchmark_zoo/toroidal_sector.py
@@ -2,7 +2,6 @@ import math
 
 from .utils import BaseCommonGeometryObject
 
-
 class ToroidalSector(BaseCommonGeometryObject):
     def __init__(self, major_radius=10, minor_radius=2, angle=90):
         self.major_radius = major_radius
@@ -28,21 +27,11 @@ class ToroidalSector(BaseCommonGeometryObject):
             a=math.sin(theta), b=-math.cos(theta), c=0, d=0
         )
 
-        # Bounding cylinder
-        outer_cyl = openmc.ZCylinder(r=R + r + 1, boundary_type="vacuum")
-        z_top = openmc.ZPlane(z0=r + 1, boundary_type="vacuum")
-        z_bot = openmc.ZPlane(z0=-(r + 1), boundary_type="vacuum")
-
         region_material = -torus & +y_plane & +upper_plane
-        region_void = (
-            -outer_cyl & +z_bot & -z_top
-            & (+torus | -y_plane | -upper_plane)
-        )
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/truncated_cone.py
+++ b/src/model_benchmark_zoo/truncated_cone.py
@@ -27,15 +27,12 @@ class TruncatedCone(BaseCommonGeometryObject):
         cone_surface = openmc.ZCone(z0=z_apex, r2=r2)
         z_top = openmc.ZPlane(z0=0.5 * h, boundary_type="vacuum")
         z_bot = openmc.ZPlane(z0=-0.5 * h, boundary_type="vacuum")
-        outer_cyl = openmc.ZCylinder(r=r_bot, boundary_type="vacuum")
 
         region_material = -cone_surface & +z_bot & -z_top
-        region_void = +cone_surface & -outer_cyl & +z_bot & -z_top
 
         cell1 = openmc.Cell(region=region_material, fill=materials[0])
-        cell2 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2])
+        geometry = openmc.Geometry([cell1])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model

--- a/src/model_benchmark_zoo/two_annular_sectors.py
+++ b/src/model_benchmark_zoo/two_annular_sectors.py
@@ -2,7 +2,6 @@ import math
 
 from .utils import BaseCommonGeometryObject
 
-
 class _TwoAnnularSectorsBase(BaseCommonGeometryObject):
     """Two nested annular sectors sharing part of a curved surface.
 
@@ -87,7 +86,6 @@ class _TwoAnnularSectorsBase(BaseCommonGeometryObject):
             second_start = radial_plane(start)
             second_end = radial_plane(start + self.second_angle)
 
-        wedge = +sector_start & -sector_end & +z_bot & -z_top & -outer_cyl
 
         # first sector: full height and full angle, between inner and mid radius
         region1 = (
@@ -97,13 +95,11 @@ class _TwoAnnularSectorsBase(BaseCommonGeometryObject):
         region2 = (
             +mid_cyl & -outer_cyl & +z2_bot & -z2_top & +second_start & -second_end
         )
-        region_void = wedge & ~region1 & ~region2
 
         cell1 = openmc.Cell(region=region1, fill=materials[0])
         cell2 = openmc.Cell(region=region2, fill=materials[1])
-        cell3 = openmc.Cell(region=region_void)
 
-        geometry = openmc.Geometry([cell1, cell2, cell3])
+        geometry = openmc.Geometry([cell1, cell2])
         my_materials = openmc.Materials(materials)
         model = openmc.Model(geometry=geometry, materials=my_materials)
         return model
@@ -147,7 +143,6 @@ class _TwoAnnularSectorsBase(BaseCommonGeometryObject):
         )
         return assembly
 
-
 class TwoAnnularSectors(_TwoAnnularSectorsBase):
     """Two annular sectors meeting over a band of a shared curved surface.
 
@@ -178,7 +173,6 @@ class TwoAnnularSectors(_TwoAnnularSectorsBase):
             angle=angle,
             second_angle=angle,
         )
-
 
 class TwoAnnularSectorsPartialArc(_TwoAnnularSectorsBase):
     """Two annular sectors meeting over an island patch of a shared curved surface.

--- a/src/model_benchmark_zoo/utils.py
+++ b/src/model_benchmark_zoo/utils.py
@@ -42,55 +42,32 @@ class BaseCommonGeometryObject:
                           max(b.ymax for b in boxes),
                           max(b.zmax for b in boxes)]))
 
-    def bounding_box(self, materials):
+    def bounding_box(self):
         """Return the padded bounding box shared by the CSG and the CAD model.
 
-        The box has to contain both representations, so it is the union of the
-        extent OpenMC reports for the CSG geometry and the exact extent of the
-        CadQuery solids. Neither alone is sufficient.
-
-        OpenMC propagates bounding boxes one surface at a time, so it cannot
-        work out that truncating an infinite surface also bounds it sideways. A
+        The extent comes from the CadQuery solids. OpenMC cannot be used for it,
+        because it propagates bounding boxes one surface at a time and so cannot
+        work out that truncating an infinite surface also bounds it sideways: a
         cone cut by two planes is reported as bounded in z but infinite in x and
-        y, and a torus sector is reported as the whole torus, so the CSG extent
-        is sometimes infinite and often loose. The CAD extent fills those gaps,
-        being exact and always finite.
+        y, and a torus sector is reported as the whole torus. The CAD extent has
+        neither problem, being exact and always finite, and it is the geometry
+        the DAGMC mesh is built from.
 
-        The CAD extent cannot be used on its own, because several models build
-        cells that reach beyond the solids. The hemisphere fills the unused half
-        of its sphere with a void cell and the Oktavian model surrounds itself
-        with void out to a radius of 100. A box drawn round the solids alone
-        cuts through those cells and OpenMC then loses particles crossing them.
-
-        Args:
-            materials: materials to build the CSG model with, only used to
-                construct the geometry whose extent is measured.
+        This is only safe because :meth:`csg_model` keeps the filled cells alone.
+        A void cell is free to reach anywhere, and several models used to define
+        one that did, so a box drawn round the solids would have cut through it.
 
         Returns:
             The lower left and upper right corners as two tuples of floats.
         """
-        import numpy as np
-
-        csg_lower, csg_upper = self._csg_model(materials).geometry.bounding_box
-        cad_lower, cad_upper = self.cad_bounding_box()
-
-        # Fall back to the CAD value wherever OpenMC reports an infinity, then
-        # take whichever extent reaches further in each direction.
-        csg_lower = np.array(csg_lower, dtype=float)
-        csg_upper = np.array(csg_upper, dtype=float)
-        csg_lower = np.where(np.isfinite(csg_lower), csg_lower, cad_lower)
-        csg_upper = np.where(np.isfinite(csg_upper), csg_upper, cad_upper)
-
-        lower = np.minimum(csg_lower, cad_lower)
-        upper = np.maximum(csg_upper, cad_upper)
-
+        lower, upper = self.cad_bounding_box()
         return (tuple(lower - BOUNDING_BOX_PADDING),
                 tuple(upper + BOUNDING_BOX_PADDING))
 
-    def _bounding_surface(self, materials):
+    def _bounding_surface(self):
         import openmc
 
-        lower, upper = self.bounding_box(materials)
+        lower, upper = self.bounding_box()
         return openmc.model.RectangularParallelepiped(
             lower[0], upper[0], lower[1], upper[1], lower[2], upper[2],
             boundary_type="vacuum"
@@ -105,6 +82,12 @@ class BaseCommonGeometryObject:
         particles that a non-convex shape lets back in, for example one that
         leaves the inner surface of a torus and crosses the hole, which the CAD
         model transports because it has the same void region around it.
+
+        Only the filled cells are carried over. Any void cell a model happens to
+        define is dropped, because everything the filled cells do not claim ends
+        up in the surrounding void anyway, whether it is a cavity inside the
+        geometry or the space around it. Dropping them also keeps the bounding
+        box tied to the solids, since a void cell is free to reach anywhere.
 
         Args:
             materials: materials to fill the model's cells with.
@@ -121,12 +104,12 @@ class BaseCommonGeometryObject:
             if surface.boundary_type == "vacuum":
                 surface.boundary_type = "transmission"
 
-        cells = list(geometry.get_all_cells().values())
+        cells = [c for c in geometry.get_all_cells().values() if c.fill is not None]
         occupied = cells[0].region
         for cell in cells[1:]:
             occupied = occupied | cell.region
 
-        boundary = self._bounding_surface(materials)
+        boundary = self._bounding_surface()
         surrounding_void = openmc.Cell(region=-boundary & ~occupied)
 
         return openmc.Model(
@@ -191,7 +174,7 @@ class BaseCommonGeometryObject:
         if not Path(h5m_filename).exists():
             print(f'DAGMC h5m file with filename = {h5m_filename} not found, try making use of export_h5m_file first')
 
-        boundary = self._bounding_surface(materials)
+        boundary = self._bounding_surface()
         bounding_cell = openmc.Cell(
             fill=openmc.DAGMCUniverse(h5m_filename), region=-boundary
         )


### PR DESCRIPTION
Follow up to #75, which introduced the shared bounding box.

## Why

Thirty models defined a void cell of their own, either filling a cavity inside the geometry or wrapping the space around it. Since #75 those have been redundant: `csg_model` already surrounds the model with void out to the bounding box, so anything the filled cells do not claim ends up void regardless of whether a cell says so. A model defined void cell and the base class one are physically the same thing.

They were not merely redundant, they were holding the bounding box open. A void cell is free to reach anywhere and several did: the hemisphere fills the unused half of its sphere, and the Oktavian model wraps itself in void out to a radius of 100 against solids that stop at 19.95. #75 therefore had to stretch the box to the union of the CAD and CSG extents, because a box drawn round the solids sliced through those cells and OpenMC lost particles crossing them, taking out 24 tests when tried.

## What changed

`csg_model` now carries over only the filled cells. With nothing reaching past the solids, the box can come from the CadQuery solids alone, padded by the usual 1 cm.

That is the tight box, and it is a better source than the CSG extent in its own right. CadQuery computes it with `BRepBndLib.AddOptimal`, so it is exact rather than a triangulated estimate, and it is always finite. OpenMC cannot match that, because it propagates bounding boxes one surface at a time and so cannot work out that truncating an infinite surface also bounds it sideways:

```
ZCone.bounding_box            -> [-inf -inf -inf] .. [inf inf inf]
(-cone & +ZPlane & -ZPlane)   -> [-inf -inf  -5.] .. [inf inf   5.]
```

Ten models needed the CAD fallback for exactly that reason, and the rest were getting a box looser than their geometry warranted, `ToroidalSector` being reported as the whole torus at 13 rather than its actual 12.

Removing the cells left seventeen lines of locals behind, bounding cylinders and regions built solely to define them, so those go too.

## Verification

- Full `tests/test_cad_to_dagmc` suite passes, **171 of 171**.
- All 57 models build with a finite box, exactly one void cell (the base class one), 6 vacuum surfaces, and no material falling outside the box.
- Unfiltered flux still agrees between CSG and CAD, so the property #75 added is preserved by the tighter box:

| model | CSG unfiltered | CAD unfiltered | difference |
|---|---|---|---|
| Cuboid | 6.14568 | 6.14568 | -0.000% |
| Circulartorus | 4.56628 | 4.56623 | -0.001% |
| Pipe | 7.52939 | 7.52934 | -0.001% |
| LShaped | 4.67886 | 4.67868 | -0.004% |

## Note on review

The bulk edit across thirty files was done by script and the first attempt was not clean: a regex pass removed only the opening line of multi-line `region_void = (` definitions and dropped the `geometry =` line in two files. That was caught by an AST syntax check and those four files were repaired by hand, after which the dead local removal was done through the AST rather than by regex. The end state is verified by the checks above, but the per file diffs are worth a look rather than taking the summary on trust.